### PR TITLE
Add 1% additional fee for transactions with unclear asset origin

### DIFF
--- a/src/de/tnc.md
+++ b/src/de/tnc.md
@@ -79,7 +79,9 @@ Die Gebühren variieren je nach Art der Dienstleistung, Typ des Kundenaccounts, 
 Handel von Crypto Assets ohne besonderer Betreuung als Privatperson per Banktransaktion: 1.49% Kauf, 1.99% Verkauf
 Handel von Crypto Assets ohne besonderer Betreuung als jursitische Person per Banktransaktion: 1.99% Kauf, 2.49% Verkauf
 Handel von Crypto Assets mit besonderer Betreuung als Privatperson oder als juristische Person per Banktransaktion: 5% Pauschal
-Bei Nutzung einer Kreditkarte werden die Kreditkartengebühren von 3% zusätzlich angerechnet.  
+Bei Nutzung einer Kreditkarte werden die Kreditkartengebühren von 3% zusätzlich angerechnet.
+
+Bei Transaktionen, welche möglicherweise eine unklare Herkunft der Vermögenswerte aufweisen, sind zusätzliche Abklärungen notwendig und es wird eine zusätzliche Gebühr von 1% erhoben.  
 
 ## Abwicklung von Rückerstattungen
 

--- a/src/en/tnc.md
+++ b/src/en/tnc.md
@@ -81,6 +81,8 @@ Fees vary depending on the type of service, customer account type, asset, blockc
 - Trading Crypto Assets with special assistance as an individual or legal entity via bank transfer: 5% Flat Fee
 - When using a credit card, an additional 3% credit card fee will apply.
 
+For transactions with potentially unclear origin of assets, additional clarifications are required and an additional fee of 1% will be charged.
+
 ### Handling of refunds
 
 In the event of problems with a transaction, the customer is instructed to contact DFX support via [Support](app.dfx.swiss/support) Refund requests for bank transactions must be submitted via [Support](app.dfx.swiss/support).

--- a/src/fr/tnc.md
+++ b/src/fr/tnc.md
@@ -191,6 +191,8 @@ Aperçu des frais à partir du 01.12.2022
 | Achat   | 1,49 %           | 1,99 %           |
 | Vente   | 1,99 %           | 2,49 %           |
 
+Pour les transactions dont l'origine des actifs est potentiellement peu claire, des clarifications supplémentaires sont nécessaires et des frais supplémentaires de 1% sont facturés.
+
 
 ## Redevances minimales
 

--- a/src/it/tnc.md
+++ b/src/it/tnc.md
@@ -191,6 +191,8 @@ Panoramica delle commissioni al 01.12.2022
 | Acquisto| 1,49 %           | 1,99 %           |
 | Vendita | 1,99 %           | 2,49 %           |
 
+Per le transazioni con origine potenzialmente non chiara degli asset, sono necessari ulteriori chiarimenti e viene addebitata una commissione aggiuntiva dell'1%.
+
 ## Tariffe minime
 
 


### PR DESCRIPTION
## Summary
- Added information about transactions with potentially unclear asset origins requiring additional clarifications
- Added 1% additional fee for such transactions
- Updated all 4 language versions (DE, EN, FR, IT)

## Changes
- Updated Terms and Conditions in all language versions to include the new fee structure for transactions with unclear asset origins
- The additional 1% fee applies when additional clarifications about the origin of assets are required