### PR TITLE
019ffaf6 - Align legal docs with Swiss self-hosting and limits

### DIFF
--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -120,16 +120,97 @@ DFX führt keine rein automatisierten Entscheidungsprozesse durch, die rechtsver
 Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sowie Auskunft über die zugrunde liegende Logik und die Auswirkungen des Profilings auf sie zu verlangen.
 
 
-## 4. Hosting
+## 4. Hosting und Infrastruktur
 
-### Hosting mit All-Inkl
+### API und Anwendungsplattform mit Microsoft Azure
 
-Wir hosten unsere Website bei All-Inkl. Anbieter ist ALL-INKL.COM - Neue Medien Münnich, Inh. René Münnich, Hauptstrasse 68, 02742 Friedersdorf (im Folgenden: All-Inkl). 
+Die Kern-Infrastruktur von DFX — insbesondere die API (api.dfx.swiss), die Anwendungsplattform (app.dfx.swiss) sowie die Datenbank — wird auf Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) betrieben. Sämtliche personenbezogenen Daten, die im Rahmen der Nutzung unserer Finanzdienstleistungen verarbeitet werden (einschliesslich Kundendaten, Transaktionsdaten, KYC-Daten und Ausweisdokumente), werden auf Azure-Infrastruktur gespeichert und verarbeitet.
 
-All-Inkl hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in den [Datenschutzbestimmungen von All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+DFX setzt Azure App Services, Azure Storage, Azure CDN sowie eine Microsoft SQL Server-Datenbank ein. Die Datenverarbeitung erfolgt in europäischen Azure-Rechenzentren. Microsoft hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Die Datenübermittlung in die USA (soweit anwendbar) erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks sowie der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
+
+Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement) sowie in den [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+
+### Informationswebsite mit All-Inkl
+
+Die Informationswebsite (dfx.swiss) sowie die Dokumentationsseite (docs.dfx.swiss) werden bei All-Inkl gehostet. Anbieter ist ALL-INKL.COM - Neue Medien Münnich, Inh. René Münnich, Hauptstrasse 68, 02742 Friedersdorf, Deutschland (im Folgenden: All-Inkl). Auf diesen Seiten werden keine personenbezogenen Kundendaten verarbeitet.
+
+Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in den [Datenschutzbestimmungen von All-Inkl](https://all-inkl.com/datenschutzinformationen/).
 
 
-## 5. Allgemeine Hinweise und Pflicht­informationen
+## 5. Auftragsverarbeiter und Drittanbieter
+
+DFX setzt zur Erbringung ihrer Dienstleistungen verschiedene externe Auftragsverarbeiter ein. Diese verarbeiten personenbezogene Daten ausschliesslich im Auftrag und nach Weisung von DFX. DFX stellt durch vertragliche Vereinbarungen sicher, dass alle Auftragsverarbeiter ein angemessenes Datenschutzniveau gewährleisten.
+
+### Identitätsprüfung (KYC) mit Sumsub
+
+Für die gesetzlich vorgeschriebene Identitätsprüfung (Know Your Customer, KYC) setzt DFX den Dienstleister Sumsub (Sum and Substance Ltd., England und Wales, Company No. 09688671) als Auftragsverarbeiter ein.
+
+#### Verarbeitete Daten
+
+Im Rahmen der Identitätsprüfung werden folgende personenbezogene Daten an Sumsub übermittelt und von Sumsub verarbeitet:
+
+* Personalien: Vorname, Nachname, Geburtsdatum, Nationalität
+* Anschrift: Strasse, Hausnummer, Postleitzahl, Ort, Land
+* Ausweisdokumente: Reisepass, Personalausweis oder andere amtliche Ausweise (Kopien/Fotos)
+* Biometrische Daten: Gesichtsbilder (Selfies), Gesichtserkennung und Liveness-Detection zur Überprüfung der Identität
+* Video-Aufnahmen: Im Rahmen der Video-Identifikation (sofern erforderlich)
+
+#### Besonders schützenswerte Daten (Art. 5 lit. c DSG)
+
+Die im Rahmen der Identitätsprüfung verarbeiteten biometrischen Daten (Gesichtsgeometrie, Liveness-Detection) gelten als besonders schützenswerte Personendaten im Sinne von Art. 5 lit. c DSG. Die Verarbeitung dieser Daten erfolgt ausschliesslich auf Grundlage Ihrer ausdrücklichen Einwilligung gemäss Art. 6 Abs. 7 DSG, die Sie vor Beginn des Identifikationsprozesses separat erteilen. Sie können diese Einwilligung jederzeit für die Zukunft widerrufen; ein Widerruf hat jedoch zur Folge, dass die Identitätsprüfung nicht abgeschlossen werden kann und bestimmte Dienstleistungen von DFX nicht genutzt werden können.
+
+#### Datenübermittlung ins Ausland
+
+Sumsub hat seinen Sitz in England und Wales (Vereinigtes Königreich). Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss des Schweizerischen Bundesrats gemäss Art. 16 Abs. 1 DSG, wodurch ein angemessenes Datenschutzniveau gewährleistet ist und keine zusätzlichen Garantien erforderlich sind.
+
+#### Speicherdauer
+
+Die im Rahmen der Identitätsprüfung erhobenen Dokumente und biometrischen Daten werden von DFX für die Dauer der gesetzlich vorgeschriebenen Aufbewahrungsfrist von 10 Jahren nach Beendigung der Geschäftsbeziehung gespeichert (Art. 7 GwG). Biometrische Rohdaten bei Sumsub werden gemäss den vertraglichen Vereinbarungen nach Abschluss der Prüfung gelöscht.
+
+Weitere Informationen zum Datenschutz bei Sumsub finden Sie in der [Datenschutzrichtlinie von Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Betrugsprävention mit Sift
+
+DFX setzt den Dienstleister Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) als Auftragsverarbeiter zur Betrugsprävention und Geldwäschereibekämpfung ein.
+
+#### Verarbeitete Daten
+
+Im Rahmen der Betrugsprävention werden folgende Daten an Sift übermittelt:
+
+* Kontoinformationen: Benutzer-ID, Erstellungsdatum, KYC-Stufe
+* Transaktionsdaten: Betrag, Währung, Zahlungsmethode (letzte 4 Ziffern der Kreditkarte bzw. erste 6 und letzte 4 Ziffern der IBAN), Blockchain-Adresse
+* Technische Daten: IP-Adresse, Geräteinformationen, Browser-Typ
+* Anmeldedaten: Zeitpunkt und Art der Anmeldung
+
+#### Datenübermittlung ins Ausland
+
+Sift hat seinen Sitz in den USA. Die Datenübermittlung erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks, sofern Sift unter diesem Framework zertifiziert ist, oder auf Grundlage von Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
+
+Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Sanktionsprüfung mit Dilisense
+
+DFX setzt den Dienstleister Dilisense für die Überprüfung von Kunden gegen Sanktionslisten, PEP-Listen (politisch exponierte Personen) und Strafregister ein. Im Rahmen dieser Prüfung werden Name, Geburtsdatum und Nationalität des Kunden übermittelt.
+
+### Serverseitiges Monitoring mit Azure Application Insights
+
+DFX setzt Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) zum Zweck der Betriebsüberwachung, Fehlererkennung und Leistungsoptimierung der API-Infrastruktur ein. Application Insights ist kein Website-Analyse-Tool zur Erfassung von Nutzerverhalten, sondern ein serverseitiges Monitoring-Werkzeug.
+
+#### Verarbeitete Daten
+
+* Technische Anfragedaten: URL-Pfade, HTTP-Statuscodes, Antwortzeiten
+* Fehler- und Ausnahmeprotokolle: Stack-Traces, Fehlermeldungen
+* Abhängigkeiten: Aufrufe an Datenbanken und externe Dienste
+* IP-Adressen: Im Rahmen der Anfrageverarbeitung
+
+Es werden keine personenbezogenen Inhalte (wie Namen, Adressen oder Finanzdaten) an Application Insights übermittelt.
+
+#### Datenübermittlung ins Ausland
+
+Microsoft kann Daten in Rechenzentren ausserhalb der Schweiz verarbeiten (EU/USA). Die Datenübermittlung erfolgt auf Grundlage der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG sowie des Swiss-US Data Privacy Frameworks. Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement).
+
+
+## 6. Allgemeine Hinweise und Pflichtinformationen
 
 ### Speicherdauer
 
@@ -172,7 +253,17 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Wir verwenden für das Hosting namens All-Inkl, ein Unternehmen aus Deutschland. Wenn diese Tools aufgerufen werden, werden Ihre personenbezogene Daten in diesen Drittstaat übertragen und könnten dort verarbeitet werden.
+Im Rahmen unserer Geschäftstätigkeit werden personenbezogene Daten an Empfänger in folgenden Staaten übermittelt:
+
+| Empfänger | Land | Zweck | Rechtsgrundlage |
+|-----------|------|-------|-----------------|
+| Microsoft Corporation (Azure) | EU / USA | Hosting der API, Datenbank, App-Plattform, Monitoring | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
+| Sumsub (Sum and Substance Ltd.) | Vereinigtes Königreich | Identitätsprüfung (KYC) | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
+| Sift Science, Inc. | USA | Betrugsprävention | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
+| Dilisense | EU | Sanktions- und PEP-Prüfung | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
+| All-Inkl (ALL-INKL.COM - Neue Medien Münnich) | Deutschland (EU) | Hosting der Informationswebsite (keine Kundendaten) | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
+
+DFX übermittelt personenbezogene Daten nur in Staaten, die über ein angemessenes Datenschutzniveau verfügen (gemäss Anhang 1 der Datenschutzverordnung), oder unter Anwendung geeigneter Garantien wie Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Zusätzlich können im Rahmen von Banktransaktionen Kundendaten an beteiligte Banken im In- und Ausland übermittelt werden (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 
@@ -197,7 +288,7 @@ Die oben genannten Rechte können verweigert oder eingeschränkt werden, wenn di
 Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit widersprochen. Die Betreiber der Seiten behalten sich ausdrücklich rechtliche Schritte im Falle der unverlangten Zusendung von Werbeinformationen, wie etwa durch Spam-E-Mails, vor.
 
 
-## 6. Datenschutzverletzungen
+## 7. Datenschutzverletzungen
 
 DFX nimmt Datenschutzverletzungen sehr ernst und hat Prozesse implementiert, um solche Vorfälle effizient und in Übereinstimmung mit den gesetzlichen Vorschriften zu bearbeiten. Eine Datenschutzverletzung liegt vor, wenn personenbezogene Daten unbeabsichtigt oder unrechtmässig offengelegt, verändert, gelöscht oder unberechtigt zugänglich gemacht werden.
 
@@ -213,8 +304,9 @@ Im Falle einer Datenschutzverletzung verfolgt DFX ein strukturiertes Vorgehen, u
 
 Im Falle einer Datenschutzverletzung, die ein Risiko für die Rechte und Freiheiten betroffener Personen darstellt, ist DFX gesetzlich verpflichtet, bestimmte Parteien zu informieren. Diese Benachrichtigungen sollen sicherstellen, dass sowohl die zuständigen Behörden als auch die betroffenen Personen rechtzeitig über die Verletzung und die ergriffenen Massnahmen informiert werden. Die Benachrichtigungen erfolgen unter Einhaltung der gesetzlichen Vorgaben und umfassen folgende Schritte:
 
-* Benachrichtigung der Aufsichtsbehörde innerhalb von 72 Stunden nach Bekanntwerden der Verletzung.
-* Benachrichtigung der betroffenen Personen unverzüglich und in klarer, verständlicher Sprache.
+* Benachrichtigung der zuständigen Aufsichtsbehörde (EDÖB) so rasch wie möglich nach Bekanntwerden der Verletzung (Art. 24 Abs. 1 DSG).
+* Benachrichtigung der betroffenen Personen, sofern es zu deren Schutz erforderlich ist oder der EDÖB dies verlangt (Art. 24 Abs. 4 DSG), unverzüglich und in klarer, verständlicher Sprache.
+* Auftragsverarbeiter von DFX (wie Sumsub, Sift und weitere) sind vertraglich verpflichtet, DFX unverzüglich über Datenschutzverletzungen zu informieren (Art. 24 Abs. 3 DSG).
    
 ### Schutzmassnahmen
 
@@ -225,7 +317,7 @@ Um Datenschutzverletzungen vorzubeugen, setzen wir technische und organisatorisc
 Wenn Sie eine mögliche Datenschutzverletzung bemerken, wenden Sie sich bitte an an unseren [Support](https://services.dfx.swiss/support) wenden.
 
 
-## 7. Datenerfassung auf dieser Website
+## 8. Datenerfassung auf dieser Website
 
 ### Cookies
 
@@ -238,12 +330,14 @@ Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird Ihre Anfrage in
 Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (zum Beispiel nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
 
 
-## 8. Analyse-Tools und Werbung
+## 9. Analyse-Tools und Werbung
 
-DFX verwendet keine Website-Analyse-Tools wie zum Beispiel Google Analytics, Adobe Analytics oder andere.
+DFX verwendet keine Website-Analyse-Tools zur Erfassung von Nutzerverhalten wie zum Beispiel Google Analytics, Adobe Analytics oder vergleichbare Dienste. Es werden keine Tracking-Pixel, Werbecookies oder ähnliche Technologien zur Analyse des Nutzerverhaltens eingesetzt.
+
+Für die serverseitige Betriebsüberwachung der API-Infrastruktur setzt DFX Microsoft Azure Application Insights ein (siehe Abschnitt 5 «Auftragsverarbeiter und Drittanbieter»). Dieses Werkzeug dient ausschliesslich der technischen Überwachung, Fehlererkennung und Leistungsoptimierung und erfasst keine Daten zum Nutzerverhalten auf der Website.
 
 
-## 9. Newsletter und Social Media
+## 10. Newsletter und Social Media
 
 ### Newsletter­daten
 
@@ -312,7 +406,7 @@ Die Datenübertragung in die USA wird auf die Standardvertragsklauseln der EU-Ko
 Details zu deren Umgang mit Ihren personenbezogenen Daten entnehmen Sie der [Datenschutzrichtlinie von LinkedIn](https://www.linkedin.com/legal/privacy-policy).
 
 
-## 10. Datenschutz bei Bewerbungen und im Bewerbungsverfahren
+## 11. Datenschutz bei Bewerbungen und im Bewerbungsverfahren
 
 Der für die Bearbeitung Verantwortliche erhebt und verarbeitet die personenbezogenen Daten von Bewerbenden zum Zweck der Durchführung des Bewerbungsverfahrens. Diese Verarbeitung kann auch elektronisch erfolgen, insbesondere wenn Bewerbende zusätzlich relevante Bewerbungsunterlagen per E-Mail (zum Beispiel im PDF-Format oder anderen Dateitypen) übermitteln.
 
@@ -325,20 +419,20 @@ Sollte der für die Bearbeitung Verantwortliche einen Arbeitsvertrag mit einer B
 Wird kein Arbeitsvertrag abgeschlossen, werden die Bewerbungsunterlagen 12 Monate nach Bekanntgabe der Ablehnungsentscheidung automatisch und ohne weitere Benachrichtigung gelöscht, sofern keine sonstigen berechtigten Interessen der datenverarbeitenden Stelle der Löschung entgegenstehen. Berechtigte Interessen können beispielsweise Nachweispflichten in Verfahren nach dem Gleichstellungsgesetz (GlG) sein.
 
 
-## 11. Anwendbares Recht und Gerichtsstand
+## 12. Anwendbares Recht und Gerichtsstand
 
 Für die Website von DFX mit Sitz in der Schweiz ist ausschliesslich Schweizer (Datenschutz-)Recht anwendbar, sofern nicht anderes zwingendes Recht auf die betroffene natürliche Person anwendbar ist.
 
 Für alle allfälligen Streitigkeiten zwischen Ihnen als Besucher und Nutzer der Website von DFX, die sich aus dem Betrieb oder dem Besuch der Websites ergeben, ist ausschliesslich das Gericht am Sitz von DFX (Schweiz) zuständig, sofern nicht für die betroffene natürliche Person ein anderer zwingender Gerichtsstand anwendbar ist.
 
 
-## 12. Änderungen der Datenschutzerklärung
+## 13. Änderungen der Datenschutzerklärung
 
 DFX überprüft diese Datenschutzerklärung regelmässig, um sicherzustellen, dass sie stets aktuell ist, und behält sich das Recht vor, sie bei Bedarf zu ändern. Es wird empfohlen, diese Seite regelmässig auf mögliche Änderungen zu überprüfen, da keine individuelle Benachrichtigung bei Änderungen erfolgt.  
 Bei Unstimmigkeiten mit der englischen Version ist die deutsche Fassung dieser Datenschutzerklärung massgebend.
 
 
-## 13. Rechtliche Hinweise und Haftungsausschluss
+## 14. Rechtliche Hinweise und Haftungsausschluss
 
 DFX übernimmt keine Haftung für die Richtigkeit und Vollständigkeit des Inhalts der Informationen.
 
@@ -347,19 +441,19 @@ Haftungsansprüche, die sich auf Schäden materieller oder ideeller Art beziehen
 Alle von DFX in digitaler oder elektronischer Form veröffentlichten Angebote sind freibleibend. DFX behält es sich ausdrücklich vor, Teile der Seiten oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
 
 
-## 14. Haftung für Links
+## 15. Haftung für Links
 
 Verweise und Links auf Websites Dritter liegen ausserhalb der Verantwortung von DFX. Jegliche Verantwortung für Websites von Dritten, das heisst ausserhalb der zu DFX gehörenden Unternehmen, wird abgelehnt. Der Zugang zu und die Nutzung von solchen Websites erfolgt auf eigenes Risiko des Nutzers.
 
 Alle von DFX in digitaler oder elektronischer Form veröffentlichten Angebote sind freibleibend. DFX behält es sich ausdrücklich vor, Teile der Seiten oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
 
 
-## 15. Urheberrechte und Geistiges Eigentum 
+## 16. Urheberrechte und Geistiges Eigentum 
 
 Das Urheberrecht und alle anderen Rechte an den Inhalten, Bildern, Fotos oder anderen Dateien auf der DFX-Website gehören ausschliesslich DFX und den mit ihr verbundenen Unternehmen, deren Lieferanten oder den namentlich genannten Rechtsinhabern.
 
 
-## 16. Zustimmung zur Datenschutzerklärung
+## 17. Zustimmung zur Datenschutzerklärung
 
 Der Kunde akzeptiert den Inhalt der Datenschutzerklärung in der jeweils aktuellen Fassung vollumfänglich. Die Datenschutzerklärung hat im Falle von Widersprüchen Vorrang vor den Allgemeinen Geschäftsbedingungen von DFX.
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -224,7 +224,7 @@ Im Falle einer Datenschutzverletzung, die voraussichtlich zu einem hohen Risiko 
 
 * Benachrichtigung der zuständigen Aufsichtsbehörde (EDÖB) so rasch wie möglich nach Bekanntwerden der Verletzung (Art. 24 Abs. 1 DSG).
 * Benachrichtigung der betroffenen Personen, sofern es zu deren Schutz erforderlich ist oder der EDÖB dies verlangt (Art. 24 Abs. 4 DSG), unverzüglich und in klarer, verständlicher Sprache.
-* Auftragsverarbeiter von DFX (wie Sumsub, Sift und weitere) sind vertraglich verpflichtet, DFX unverzüglich über Datenschutzverletzungen zu informieren (Art. 24 Abs. 3 DSG).
+* Die oben genannten Auftragsverarbeiter sind vertraglich verpflichtet, DFX unverzüglich über Datenschutzverletzungen zu informieren (Art. 24 Abs. 3 DSG).
    
 ### Schutzmassnahmen
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -122,9 +122,9 @@ Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sow
 
 ## 4. Hosting und Infrastruktur
 
-Statische Websites ohne Kundendaten (etwa dfx.swiss) hostet DFX bei Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
+Statische Informationsseiten, auf denen keine Kundendaten erfasst werden (etwa dfx.swiss), hostet DFX bei Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Auf diesen Seiten gibt es kein Kundenkonto, keine Transaktionen und keine Identitätsprüfung.
 
-API, Anwendungsplattform und Datenbank betreibt DFX auf eigenen Servern in der Schweiz. Der öffentliche Zugang zu diesen Diensten erfolgt über Cloudflare als Content Delivery Network und Reverse Proxy.
+Alles, was Kundendaten verarbeitet — API, Anwendungsplattform und Datenbank — betreibt DFX auf eigenen Servern in der Schweiz. Der öffentliche Zugang zu diesen Diensten erfolgt über Cloudflare als Content Delivery Network und Reverse Proxy.
 
 Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) an Cloudflare übermittelt. Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Einzelheiten: [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/) und [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Websites und Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
+Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Seiten ohne Kundendaten und Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -120,7 +120,7 @@ DFX führt keine rein automatisierten Entscheidungsprozesse durch, die rechtsver
 Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sowie Auskunft über die zugrunde liegende Logik und die Auswirkungen des Profilings auf sie zu verlangen.
 
 
-## 4. Hosting
+## 4. Hosting und Infrastruktur
 
 ### Hosting mit Cloudflare Pages
 
@@ -128,8 +128,89 @@ Wir hosten unsere Website bei Cloudflare Pages. Anbieter ist Cloudflare, Inc., 1
 
 Cloudflare hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in der [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/). Die Verarbeitung in unserem Auftrag erfolgt auf Grundlage des [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
+### API und Anwendungsplattform mit Microsoft Azure
 
-## 5. Allgemeine Hinweise und Pflicht­informationen
+Die Kern-Infrastruktur von DFX — insbesondere die API (api.dfx.swiss), die Anwendungsplattform (app.dfx.swiss) sowie die Datenbank — wird auf Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) betrieben. Sämtliche personenbezogenen Daten, die im Rahmen der Nutzung unserer Finanzdienstleistungen verarbeitet werden (einschliesslich Kundendaten, Transaktionsdaten, KYC-Daten und Ausweisdokumente), werden auf Azure-Infrastruktur gespeichert und verarbeitet.
+
+DFX setzt Azure App Services, Azure Storage, Azure CDN sowie eine Microsoft SQL Server-Datenbank ein. Die Datenverarbeitung erfolgt in europäischen Azure-Rechenzentren. Microsoft hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Die Datenübermittlung in die USA (soweit anwendbar) erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks sowie der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
+
+Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement) sowie in den [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+
+
+## 5. Auftragsverarbeiter und Drittanbieter
+
+DFX setzt zur Erbringung ihrer Dienstleistungen verschiedene externe Auftragsverarbeiter ein. Diese verarbeiten personenbezogene Daten ausschliesslich im Auftrag und nach Weisung von DFX. DFX stellt durch vertragliche Vereinbarungen sicher, dass alle Auftragsverarbeiter ein angemessenes Datenschutzniveau gewährleisten.
+
+### Identitätsprüfung (KYC) mit Sumsub
+
+Für die gesetzlich vorgeschriebene Identitätsprüfung (Know Your Customer, KYC) setzt DFX den Dienstleister Sumsub (Sum and Substance Ltd., England und Wales, Company No. 09688671) als Auftragsverarbeiter ein.
+
+#### Verarbeitete Daten
+
+Im Rahmen der Identitätsprüfung werden folgende personenbezogene Daten an Sumsub übermittelt und von Sumsub verarbeitet:
+
+* Personalien: Vorname, Nachname, Geburtsdatum, Nationalität
+* Anschrift: Strasse, Hausnummer, Postleitzahl, Ort, Land
+* Ausweisdokumente: Reisepass, Personalausweis oder andere amtliche Ausweise (Kopien/Fotos)
+* Biometrische Daten: Gesichtsbilder (Selfies), Gesichtserkennung und Liveness-Detection zur Überprüfung der Identität
+* Video-Aufnahmen: Im Rahmen der Video-Identifikation (sofern erforderlich)
+
+#### Besonders schützenswerte Daten (Art. 5 lit. c DSG)
+
+Die im Rahmen der Identitätsprüfung verarbeiteten biometrischen Daten (Gesichtsgeometrie, Liveness-Detection) gelten als besonders schützenswerte Personendaten im Sinne von Art. 5 lit. c DSG. Die Verarbeitung dieser Daten erfolgt ausschliesslich auf Grundlage Ihrer ausdrücklichen Einwilligung gemäss Art. 6 Abs. 7 DSG, die Sie vor Beginn des Identifikationsprozesses separat erteilen. Sie können diese Einwilligung jederzeit für die Zukunft widerrufen; ein Widerruf hat jedoch zur Folge, dass die Identitätsprüfung nicht abgeschlossen werden kann und bestimmte Dienstleistungen von DFX nicht genutzt werden können.
+
+#### Datenübermittlung ins Ausland
+
+Sumsub hat seinen Sitz in England und Wales (Vereinigtes Königreich). Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss des Schweizerischen Bundesrats gemäss Art. 16 Abs. 1 DSG, wodurch ein angemessenes Datenschutzniveau gewährleistet ist und keine zusätzlichen Garantien erforderlich sind.
+
+#### Speicherdauer
+
+Die im Rahmen der Identitätsprüfung erhobenen Dokumente und biometrischen Daten werden von DFX für die Dauer der gesetzlich vorgeschriebenen Aufbewahrungsfrist von 10 Jahren nach Beendigung der Geschäftsbeziehung gespeichert (Art. 7 GwG). Biometrische Rohdaten bei Sumsub werden gemäss den vertraglichen Vereinbarungen nach Abschluss der Prüfung gelöscht.
+
+Weitere Informationen zum Datenschutz bei Sumsub finden Sie in der [Datenschutzrichtlinie von Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Betrugsprävention mit Sift
+
+DFX setzt den Dienstleister Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) als Auftragsverarbeiter zur Betrugsprävention und Geldwäschereibekämpfung ein.
+
+#### Verarbeitete Daten
+
+Im Rahmen der Betrugsprävention werden folgende Daten an Sift übermittelt:
+
+* Kontoinformationen: Benutzer-ID, Erstellungsdatum, KYC-Stufe
+* Transaktionsdaten: Betrag, Währung, Zahlungsmethode (letzte 4 Ziffern der Kreditkarte bzw. erste 6 und letzte 4 Ziffern der IBAN), Blockchain-Adresse
+* Technische Daten: IP-Adresse, Geräteinformationen, Browser-Typ
+* Anmeldedaten: Zeitpunkt und Art der Anmeldung
+
+#### Datenübermittlung ins Ausland
+
+Sift hat seinen Sitz in den USA. Die Datenübermittlung erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks, sofern Sift unter diesem Framework zertifiziert ist, oder auf Grundlage von Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
+
+Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Sanktionsprüfung mit Dilisense
+
+DFX setzt den Dienstleister Dilisense für die Überprüfung von Kunden gegen Sanktionslisten, PEP-Listen (politisch exponierte Personen) und Strafregister ein. Im Rahmen dieser Prüfung werden Name, Geburtsdatum und Nationalität des Kunden übermittelt.
+
+### Serverseitiges Monitoring mit Azure Application Insights
+
+DFX setzt Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) zum Zweck der Betriebsüberwachung, Fehlererkennung und Leistungsoptimierung der API-Infrastruktur ein. Application Insights ist kein Website-Analyse-Tool zur Erfassung von Nutzerverhalten, sondern ein serverseitiges Monitoring-Werkzeug.
+
+#### Verarbeitete Daten
+
+* Technische Anfragedaten: URL-Pfade, HTTP-Statuscodes, Antwortzeiten
+* Fehler- und Ausnahmeprotokolle: Stack-Traces, Fehlermeldungen
+* Abhängigkeiten: Aufrufe an Datenbanken und externe Dienste
+* IP-Adressen: Im Rahmen der Anfrageverarbeitung
+
+Es werden keine personenbezogenen Inhalte (wie Namen, Adressen oder Finanzdaten) an Application Insights übermittelt.
+
+#### Datenübermittlung ins Ausland
+
+Microsoft kann Daten in Rechenzentren ausserhalb der Schweiz verarbeiten (EU/USA). Die Datenübermittlung erfolgt auf Grundlage der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG sowie des Swiss-US Data Privacy Frameworks. Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement).
+
+
+## 6. Allgemeine Hinweise und Pflichtinformationen
 
 ### Speicherdauer
 
@@ -176,6 +257,18 @@ Wir nutzen für das Hosting Cloudflare Pages, einen Dienst der Cloudflare, Inc. 
 
 Rechtsgrundlage der Datenübermittlung in die USA: Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und nach dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf die Standardvertragsklauseln der EU-Kommission. Wir weisen darauf hin, dass trotz dieser Schutzmechanismen ein Zugriff durch US-Behörden (z. B. nach dem CLOUD Act) nicht vollständig ausgeschlossen werden kann.
 
+Im Rahmen unserer Geschäftstätigkeit werden personenbezogene Daten an Empfänger in folgenden Staaten übermittelt:
+
+| Empfänger | Land | Zweck | Rechtsgrundlage |
+|-----------|------|-------|-----------------|
+| Microsoft Corporation (Azure) | EU / USA | Hosting der API, Datenbank, App-Plattform, Monitoring | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
+| Sumsub (Sum and Substance Ltd.) | Vereinigtes Königreich | Identitätsprüfung (KYC) | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
+| Sift Science, Inc. | USA | Betrugsprävention | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
+| Dilisense | EU | Sanktions- und PEP-Prüfung | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
+| Cloudflare, Inc. | USA | Hosting der Website und Dokumentation (Cloudflare Pages) | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
+
+DFX übermittelt personenbezogene Daten nur in Staaten, die über ein angemessenes Datenschutzniveau verfügen (gemäss Anhang 1 der Datenschutzverordnung), oder unter Anwendung geeigneter Garantien wie Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Zusätzlich können im Rahmen von Banktransaktionen Kundendaten an beteiligte Banken im In- und Ausland übermittelt werden (siehe Allgemeine Geschäftsbedingungen).
+
 ### SSL- bzw. TLS-Verschlüsselung
 
 Aus Sicherheitsgründen und zum Schutz der Übertragung vertraulicher Inhalte, wie zum Beispiel Anfragen, die Sie an uns als Seitenbetreiber senden, verwendet diese Seite eine SSL- bzw. TLS-Verschlüsselung. Eine verschlüsselte Verbindung erkennen Sie daran, dass die Adresszeile des Browsers von «http://» auf «https://» wechselt und an dem Schloss-Symbol in Ihrer Browserzeile.
@@ -199,7 +292,7 @@ Die oben genannten Rechte können verweigert oder eingeschränkt werden, wenn di
 Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit widersprochen. Die Betreiber der Seiten behalten sich ausdrücklich rechtliche Schritte im Falle der unverlangten Zusendung von Werbeinformationen, wie etwa durch Spam-E-Mails, vor.
 
 
-## 6. Datenschutzverletzungen
+## 7. Datenschutzverletzungen
 
 DFX nimmt Datenschutzverletzungen sehr ernst und hat Prozesse implementiert, um solche Vorfälle effizient und in Übereinstimmung mit den gesetzlichen Vorschriften zu bearbeiten. Eine Datenschutzverletzung liegt vor, wenn personenbezogene Daten unbeabsichtigt oder unrechtmässig offengelegt, verändert, gelöscht oder unberechtigt zugänglich gemacht werden.
 
@@ -215,8 +308,9 @@ Im Falle einer Datenschutzverletzung verfolgt DFX ein strukturiertes Vorgehen, u
 
 Im Falle einer Datenschutzverletzung, die ein Risiko für die Rechte und Freiheiten betroffener Personen darstellt, ist DFX gesetzlich verpflichtet, bestimmte Parteien zu informieren. Diese Benachrichtigungen sollen sicherstellen, dass sowohl die zuständigen Behörden als auch die betroffenen Personen rechtzeitig über die Verletzung und die ergriffenen Massnahmen informiert werden. Die Benachrichtigungen erfolgen unter Einhaltung der gesetzlichen Vorgaben und umfassen folgende Schritte:
 
-* Benachrichtigung der Aufsichtsbehörde innerhalb von 72 Stunden nach Bekanntwerden der Verletzung.
-* Benachrichtigung der betroffenen Personen unverzüglich und in klarer, verständlicher Sprache.
+* Benachrichtigung der zuständigen Aufsichtsbehörde (EDÖB) so rasch wie möglich nach Bekanntwerden der Verletzung (Art. 24 Abs. 1 DSG).
+* Benachrichtigung der betroffenen Personen, sofern es zu deren Schutz erforderlich ist oder der EDÖB dies verlangt (Art. 24 Abs. 4 DSG), unverzüglich und in klarer, verständlicher Sprache.
+* Auftragsverarbeiter von DFX (wie Sumsub, Sift und weitere) sind vertraglich verpflichtet, DFX unverzüglich über Datenschutzverletzungen zu informieren (Art. 24 Abs. 3 DSG).
    
 ### Schutzmassnahmen
 
@@ -227,7 +321,7 @@ Um Datenschutzverletzungen vorzubeugen, setzen wir technische und organisatorisc
 Wenn Sie eine mögliche Datenschutzverletzung bemerken, wenden Sie sich bitte an an unseren [Support](https://services.dfx.swiss/support) wenden.
 
 
-## 7. Datenerfassung auf dieser Website
+## 8. Datenerfassung auf dieser Website
 
 ### Cookies
 
@@ -240,12 +334,14 @@ Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird Ihre Anfrage in
 Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (zum Beispiel nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
 
 
-## 8. Analyse-Tools und Werbung
+## 9. Analyse-Tools und Werbung
 
-DFX verwendet keine Website-Analyse-Tools wie zum Beispiel Google Analytics, Adobe Analytics oder andere.
+DFX verwendet keine Website-Analyse-Tools zur Erfassung von Nutzerverhalten wie zum Beispiel Google Analytics, Adobe Analytics oder vergleichbare Dienste. Es werden keine Tracking-Pixel, Werbecookies oder ähnliche Technologien zur Analyse des Nutzerverhaltens eingesetzt.
+
+Für die serverseitige Betriebsüberwachung der API-Infrastruktur setzt DFX Microsoft Azure Application Insights ein (siehe Abschnitt 5 «Auftragsverarbeiter und Drittanbieter»). Dieses Werkzeug dient ausschliesslich der technischen Überwachung, Fehlererkennung und Leistungsoptimierung und erfasst keine Daten zum Nutzerverhalten auf der Website.
 
 
-## 9. Newsletter und Social Media
+## 10. Newsletter und Social Media
 
 ### Newsletter­daten
 
@@ -314,7 +410,7 @@ Die Datenübertragung in die USA wird auf die Standardvertragsklauseln der EU-Ko
 Details zu deren Umgang mit Ihren personenbezogenen Daten entnehmen Sie der [Datenschutzrichtlinie von LinkedIn](https://www.linkedin.com/legal/privacy-policy).
 
 
-## 10. Datenschutz bei Bewerbungen und im Bewerbungsverfahren
+## 11. Datenschutz bei Bewerbungen und im Bewerbungsverfahren
 
 Der für die Bearbeitung Verantwortliche erhebt und verarbeitet die personenbezogenen Daten von Bewerbenden zum Zweck der Durchführung des Bewerbungsverfahrens. Diese Verarbeitung kann auch elektronisch erfolgen, insbesondere wenn Bewerbende zusätzlich relevante Bewerbungsunterlagen per E-Mail (zum Beispiel im PDF-Format oder anderen Dateitypen) übermitteln.
 
@@ -327,20 +423,20 @@ Sollte der für die Bearbeitung Verantwortliche einen Arbeitsvertrag mit einer B
 Wird kein Arbeitsvertrag abgeschlossen, werden die Bewerbungsunterlagen 12 Monate nach Bekanntgabe der Ablehnungsentscheidung automatisch und ohne weitere Benachrichtigung gelöscht, sofern keine sonstigen berechtigten Interessen der datenverarbeitenden Stelle der Löschung entgegenstehen. Berechtigte Interessen können beispielsweise Nachweispflichten in Verfahren nach dem Gleichstellungsgesetz (GlG) sein.
 
 
-## 11. Anwendbares Recht und Gerichtsstand
+## 12. Anwendbares Recht und Gerichtsstand
 
 Für die Website von DFX mit Sitz in der Schweiz ist ausschliesslich Schweizer (Datenschutz-)Recht anwendbar, sofern nicht anderes zwingendes Recht auf die betroffene natürliche Person anwendbar ist.
 
 Für alle allfälligen Streitigkeiten zwischen Ihnen als Besucher und Nutzer der Website von DFX, die sich aus dem Betrieb oder dem Besuch der Websites ergeben, ist ausschliesslich das Gericht am Sitz von DFX (Schweiz) zuständig, sofern nicht für die betroffene natürliche Person ein anderer zwingender Gerichtsstand anwendbar ist.
 
 
-## 12. Änderungen der Datenschutzerklärung
+## 13. Änderungen der Datenschutzerklärung
 
 DFX überprüft diese Datenschutzerklärung regelmässig, um sicherzustellen, dass sie stets aktuell ist, und behält sich das Recht vor, sie bei Bedarf zu ändern. Es wird empfohlen, diese Seite regelmässig auf mögliche Änderungen zu überprüfen, da keine individuelle Benachrichtigung bei Änderungen erfolgt.  
 Bei Unstimmigkeiten mit der englischen Version ist die deutsche Fassung dieser Datenschutzerklärung massgebend.
 
 
-## 13. Rechtliche Hinweise und Haftungsausschluss
+## 14. Rechtliche Hinweise und Haftungsausschluss
 
 DFX übernimmt keine Haftung für die Richtigkeit und Vollständigkeit des Inhalts der Informationen.
 
@@ -349,19 +445,19 @@ Haftungsansprüche, die sich auf Schäden materieller oder ideeller Art beziehen
 Alle von DFX in digitaler oder elektronischer Form veröffentlichten Angebote sind freibleibend. DFX behält es sich ausdrücklich vor, Teile der Seiten oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
 
 
-## 14. Haftung für Links
+## 15. Haftung für Links
 
 Verweise und Links auf Websites Dritter liegen ausserhalb der Verantwortung von DFX. Jegliche Verantwortung für Websites von Dritten, das heisst ausserhalb der zu DFX gehörenden Unternehmen, wird abgelehnt. Der Zugang zu und die Nutzung von solchen Websites erfolgt auf eigenes Risiko des Nutzers.
 
 Alle von DFX in digitaler oder elektronischer Form veröffentlichten Angebote sind freibleibend. DFX behält es sich ausdrücklich vor, Teile der Seiten oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
 
 
-## 15. Urheberrechte und Geistiges Eigentum 
+## 16. Urheberrechte und Geistiges Eigentum 
 
 Das Urheberrecht und alle anderen Rechte an den Inhalten, Bildern, Fotos oder anderen Dateien auf der DFX-Website gehören ausschliesslich DFX und den mit ihr verbundenen Unternehmen, deren Lieferanten oder den namentlich genannten Rechtsinhabern.
 
 
-## 16. Zustimmung zur Datenschutzerklärung
+## 17. Zustimmung zur Datenschutzerklärung
 
 Der Kunde akzeptiert den Inhalt der Datenschutzerklärung in der jeweils aktuellen Fassung vollumfänglich. Die Datenschutzerklärung hat im Falle von Widersprüchen Vorrang vor den Allgemeinen Geschäftsbedingungen von DFX.
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -122,11 +122,11 @@ Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sow
 
 ## 4. Hosting und Infrastruktur
 
-API, Anwendungsplattform und Datenbank betreibt DFX auf eigenen Servern in der Schweiz.
+Statische Websites ohne Kundendaten (etwa dfx.swiss) hostet DFX bei Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
 
-Der öffentliche Zugang zu unseren Websites und Diensten erfolgt über Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) als Content Delivery Network und Reverse Proxy. Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) an Cloudflare übermittelt.
+API, Anwendungsplattform und Datenbank betreibt DFX auf eigenen Servern in der Schweiz. Der öffentliche Zugang zu diesen Diensten erfolgt über Cloudflare als Content Delivery Network und Reverse Proxy.
 
-Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Einzelheiten: [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/) und [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
+Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) an Cloudflare übermittelt. Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Einzelheiten: [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/) und [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Auftragsverarbeiter
@@ -180,7 +180,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
+Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Websites und Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -122,92 +122,20 @@ Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sow
 
 ## 4. Hosting und Infrastruktur
 
-### Hosting mit Cloudflare Pages
+API, Anwendungsplattform und Datenbank betreibt DFX auf eigenen Servern in der Schweiz.
 
-Wir hosten unsere Website bei Cloudflare Pages. Anbieter ist Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (im Folgenden: Cloudflare).
+Der öffentliche Zugang zu unseren Websites und Diensten erfolgt über Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) als Content Delivery Network und Reverse Proxy. Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) an Cloudflare übermittelt.
 
-Cloudflare hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in der [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/). Die Verarbeitung in unserem Auftrag erfolgt auf Grundlage des [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
-
-### API und Anwendungsplattform mit Microsoft Azure
-
-Die Kern-Infrastruktur von DFX — insbesondere die API (api.dfx.swiss), die Anwendungsplattform (app.dfx.swiss) sowie die Datenbank — wird auf Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) betrieben. Sämtliche personenbezogenen Daten, die im Rahmen der Nutzung unserer Finanzdienstleistungen verarbeitet werden (einschliesslich Kundendaten, Transaktionsdaten, KYC-Daten und Ausweisdokumente), werden auf Azure-Infrastruktur gespeichert und verarbeitet.
-
-DFX setzt Azure App Services, Azure Storage, Azure CDN sowie eine Microsoft SQL Server-Datenbank ein. Die Datenverarbeitung erfolgt in europäischen Azure-Rechenzentren. Microsoft hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Die Datenübermittlung in die USA (soweit anwendbar) erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks sowie der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
-
-Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement) sowie in den [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Einzelheiten: [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/) und [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
-## 5. Auftragsverarbeiter und Drittanbieter
+## 5. Auftragsverarbeiter
 
-DFX setzt zur Erbringung ihrer Dienstleistungen verschiedene externe Auftragsverarbeiter ein. Diese verarbeiten personenbezogene Daten ausschliesslich im Auftrag und nach Weisung von DFX. DFX stellt durch vertragliche Vereinbarungen sicher, dass alle Auftragsverarbeiter ein angemessenes Datenschutzniveau gewährleisten.
+Soweit zur Vertragserfüllung oder zur Erfüllung gesetzlicher Pflichten erforderlich, setzen wir folgende Auftragsverarbeiter ein:
 
-### Identitätsprüfung (KYC) mit Sumsub
-
-Für die gesetzlich vorgeschriebene Identitätsprüfung (Know Your Customer, KYC) setzt DFX den Dienstleister Sumsub (Sum and Substance Ltd., England und Wales, Company No. 09688671) als Auftragsverarbeiter ein.
-
-#### Verarbeitete Daten
-
-Im Rahmen der Identitätsprüfung werden folgende personenbezogene Daten an Sumsub übermittelt und von Sumsub verarbeitet:
-
-* Personalien: Vorname, Nachname, Geburtsdatum, Nationalität
-* Anschrift: Strasse, Hausnummer, Postleitzahl, Ort, Land
-* Ausweisdokumente: Reisepass, Personalausweis oder andere amtliche Ausweise (Kopien/Fotos)
-* Biometrische Daten: Gesichtsbilder (Selfies), Gesichtserkennung und Liveness-Detection zur Überprüfung der Identität
-* Video-Aufnahmen: Im Rahmen der Video-Identifikation (sofern erforderlich)
-
-#### Besonders schützenswerte Daten (Art. 5 lit. c DSG)
-
-Die im Rahmen der Identitätsprüfung verarbeiteten biometrischen Daten (Gesichtsgeometrie, Liveness-Detection) gelten als besonders schützenswerte Personendaten im Sinne von Art. 5 lit. c DSG. Die Verarbeitung dieser Daten erfolgt ausschliesslich auf Grundlage Ihrer ausdrücklichen Einwilligung gemäss Art. 6 Abs. 7 DSG, die Sie vor Beginn des Identifikationsprozesses separat erteilen. Sie können diese Einwilligung jederzeit für die Zukunft widerrufen; ein Widerruf hat jedoch zur Folge, dass die Identitätsprüfung nicht abgeschlossen werden kann und bestimmte Dienstleistungen von DFX nicht genutzt werden können.
-
-#### Datenübermittlung ins Ausland
-
-Sumsub hat seinen Sitz in England und Wales (Vereinigtes Königreich). Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss des Schweizerischen Bundesrats gemäss Art. 16 Abs. 1 DSG, wodurch ein angemessenes Datenschutzniveau gewährleistet ist und keine zusätzlichen Garantien erforderlich sind.
-
-#### Speicherdauer
-
-Die im Rahmen der Identitätsprüfung erhobenen Dokumente und biometrischen Daten werden von DFX für die Dauer der gesetzlich vorgeschriebenen Aufbewahrungsfrist von 10 Jahren nach Beendigung der Geschäftsbeziehung gespeichert (Art. 7 GwG). Biometrische Rohdaten bei Sumsub werden gemäss den vertraglichen Vereinbarungen nach Abschluss der Prüfung gelöscht.
-
-Weitere Informationen zum Datenschutz bei Sumsub finden Sie in der [Datenschutzrichtlinie von Sumsub](https://sumsub.com/privacy-notice-service/).
-
-### Betrugsprävention mit Sift
-
-DFX setzt den Dienstleister Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) als Auftragsverarbeiter zur Betrugsprävention und Geldwäschereibekämpfung ein.
-
-#### Verarbeitete Daten
-
-Im Rahmen der Betrugsprävention werden folgende Daten an Sift übermittelt:
-
-* Kontoinformationen: Benutzer-ID, Erstellungsdatum, KYC-Stufe
-* Transaktionsdaten: Betrag, Währung, Zahlungsmethode (letzte 4 Ziffern der Kreditkarte bzw. erste 6 und letzte 4 Ziffern der IBAN), Blockchain-Adresse
-* Technische Daten: IP-Adresse, Geräteinformationen, Browser-Typ
-* Anmeldedaten: Zeitpunkt und Art der Anmeldung
-
-#### Datenübermittlung ins Ausland
-
-Sift hat seinen Sitz in den USA. Die Datenübermittlung erfolgt auf Grundlage des Swiss-US Data Privacy Frameworks, sofern Sift unter diesem Framework zertifiziert ist, oder auf Grundlage von Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG.
-
-Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
-
-### Sanktionsprüfung mit Dilisense
-
-DFX setzt den Dienstleister Dilisense für die Überprüfung von Kunden gegen Sanktionslisten, PEP-Listen (politisch exponierte Personen) und Strafregister ein. Im Rahmen dieser Prüfung werden Name, Geburtsdatum und Nationalität des Kunden übermittelt.
-
-### Serverseitiges Monitoring mit Azure Application Insights
-
-DFX setzt Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) zum Zweck der Betriebsüberwachung, Fehlererkennung und Leistungsoptimierung der API-Infrastruktur ein. Application Insights ist kein Website-Analyse-Tool zur Erfassung von Nutzerverhalten, sondern ein serverseitiges Monitoring-Werkzeug.
-
-#### Verarbeitete Daten
-
-* Technische Anfragedaten: URL-Pfade, HTTP-Statuscodes, Antwortzeiten
-* Fehler- und Ausnahmeprotokolle: Stack-Traces, Fehlermeldungen
-* Abhängigkeiten: Aufrufe an Datenbanken und externe Dienste
-* IP-Adressen: Im Rahmen der Anfrageverarbeitung
-
-Es werden keine personenbezogenen Inhalte (wie Namen, Adressen oder Finanzdaten) an Application Insights übermittelt.
-
-#### Datenübermittlung ins Ausland
-
-Microsoft kann Daten in Rechenzentren ausserhalb der Schweiz verarbeiten (EU/USA). Die Datenübermittlung erfolgt auf Grundlage der Standardvertragsklauseln gemäss Art. 16 Abs. 2 lit. d DSG sowie des Swiss-US Data Privacy Frameworks. Weitere Informationen finden Sie in der [Datenschutzrichtlinie von Microsoft](https://privacy.microsoft.com/de-de/privacystatement).
+* Sumsub (Sum and Substance Ltd., Vereinigtes Königreich) — gesetzlich vorgeschriebene Identitätsprüfung, einschliesslich Ausweisdokumenten und biometrischer Daten. Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG). Biometrische Daten verarbeiten wir nur mit Ihrer ausdrücklichen Einwilligung (Art. 6 Abs. 7 DSG).
+* Sift Science, Inc. (USA) — Betrugsprävention. Übermittlung gestützt auf das Swiss-U.S. Data Privacy Framework bzw. Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG).
+* Dilisense (EU) — Prüfung gegen Sanktions- und PEP-Listen. Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG).
 
 
 ## 6. Allgemeine Hinweise und Pflichtinformationen
@@ -253,21 +181,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Wir nutzen für das Hosting Cloudflare Pages, einen Dienst der Cloudflare, Inc. mit Sitz in den USA. Beim Aufruf unserer Website werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) in die USA übertragen und dort verarbeitet, da Cloudflare als Reverse Proxy / Content Delivery Network die Verbindungen terminiert.
-
-Rechtsgrundlage der Datenübermittlung in die USA: Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und nach dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf die Standardvertragsklauseln der EU-Kommission. Wir weisen darauf hin, dass trotz dieser Schutzmechanismen ein Zugriff durch US-Behörden (z. B. nach dem CLOUD Act) nicht vollständig ausgeschlossen werden kann.
-
-Im Rahmen unserer Geschäftstätigkeit werden personenbezogene Daten an Empfänger in folgenden Staaten übermittelt:
-
-| Empfänger | Land | Zweck | Rechtsgrundlage |
-|-----------|------|-------|-----------------|
-| Microsoft Corporation (Azure) | EU / USA | Hosting der API, Datenbank, App-Plattform, Monitoring | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
-| Sumsub (Sum and Substance Ltd.) | Vereinigtes Königreich | Identitätsprüfung (KYC) | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
-| Sift Science, Inc. | USA | Betrugsprävention | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
-| Dilisense | EU | Sanktions- und PEP-Prüfung | Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG) |
-| Cloudflare, Inc. | USA | Hosting der Website und Dokumentation (Cloudflare Pages) | Swiss-US DPF / Standardvertragsklauseln (Art. 16 Abs. 2 DSG) |
-
-DFX übermittelt personenbezogene Daten nur in Staaten, die über ein angemessenes Datenschutzniveau verfügen (gemäss Anhang 1 der Datenschutzverordnung), oder unter Anwendung geeigneter Garantien wie Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Zusätzlich können im Rahmen von Banktransaktionen Kundendaten an beteiligte Banken im In- und Ausland übermittelt werden (siehe Allgemeine Geschäftsbedingungen).
+Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie nur an Cloudflare (USA, Zugang zu den Diensten) sowie an die oben genannten Auftragsverarbeiter. Zusätzlich können im Rahmen von Banktransaktionen Kundendaten an beteiligte Banken im In- und Ausland übermittelt werden (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 
@@ -337,8 +251,6 @@ Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, 
 ## 9. Analyse-Tools und Werbung
 
 DFX verwendet keine Website-Analyse-Tools zur Erfassung von Nutzerverhalten wie zum Beispiel Google Analytics, Adobe Analytics oder vergleichbare Dienste. Es werden keine Tracking-Pixel, Werbecookies oder ähnliche Technologien zur Analyse des Nutzerverhaltens eingesetzt.
-
-Für die serverseitige Betriebsüberwachung der API-Infrastruktur setzt DFX Microsoft Azure Application Insights ein (siehe Abschnitt 5 «Auftragsverarbeiter und Drittanbieter»). Dieses Werkzeug dient ausschliesslich der technischen Überwachung, Fehlererkennung und Leistungsoptimierung und erfasst keine Daten zum Nutzerverhalten auf der Website.
 
 
 ## 10. Newsletter und Social Media

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -306,7 +306,7 @@ Im Falle einer Datenschutzverletzung verfolgt DFX ein strukturiertes Vorgehen, u
 
 #### Benachrichtigungspflichten
 
-Im Falle einer Datenschutzverletzung, die ein Risiko für die Rechte und Freiheiten betroffener Personen darstellt, ist DFX gesetzlich verpflichtet, bestimmte Parteien zu informieren. Diese Benachrichtigungen sollen sicherstellen, dass sowohl die zuständigen Behörden als auch die betroffenen Personen rechtzeitig über die Verletzung und die ergriffenen Massnahmen informiert werden. Die Benachrichtigungen erfolgen unter Einhaltung der gesetzlichen Vorgaben und umfassen folgende Schritte:
+Im Falle einer Datenschutzverletzung, die voraussichtlich zu einem hohen Risiko für die Persönlichkeit oder die Grundrechte der betroffenen Personen führt, ist DFX gesetzlich verpflichtet, bestimmte Parteien zu informieren. Diese Benachrichtigungen sollen sicherstellen, dass sowohl die zuständigen Behörden als auch die betroffenen Personen rechtzeitig über die Verletzung und die ergriffenen Massnahmen informiert werden. Die Benachrichtigungen erfolgen unter Einhaltung der gesetzlichen Vorgaben und umfassen folgende Schritte:
 
 * Benachrichtigung der zuständigen Aufsichtsbehörde (EDÖB) so rasch wie möglich nach Bekanntwerden der Verletzung (Art. 24 Abs. 1 DSG).
 * Benachrichtigung der betroffenen Personen, sofern es zu deren Schutz erforderlich ist oder der EDÖB dies verlangt (Art. 24 Abs. 4 DSG), unverzüglich und in klarer, verständlicher Sprache.

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -180,7 +180,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Seiten ohne Kundendaten und Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
+Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Seiten ohne Kundendaten und Zugang zu den Diensten), an Sumsub (Vereinigtes Königreich) und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -124,7 +124,7 @@ Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sow
 
 Statische Informationsseiten, auf denen keine Kundendaten erfasst werden (etwa dfx.swiss), hostet DFX bei Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Auf diesen Seiten gibt es kein Kundenkonto, keine Transaktionen und keine Identitätsprüfung.
 
-Alles, was Kundendaten verarbeitet — API, Anwendungsplattform und Datenbank — betreibt DFX auf eigenen Servern in der Schweiz. Der öffentliche Zugang zu diesen Diensten erfolgt über Cloudflare als Content Delivery Network und Reverse Proxy.
+API, Anwendungsplattform und Datenbank betreibt DFX auf eigenen Servern in der Schweiz. Der öffentliche Zugang zu diesen Diensten erfolgt über Cloudflare als Content Delivery Network und Reverse Proxy.
 
 Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) an Cloudflare übermittelt. Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG). Einzelheiten: [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/) und [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Seiten ohne Kundendaten und Zugang zu den Diensten), an Sumsub (Vereinigtes Königreich) und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
+Kundendaten der Handelsplattform werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Hosting der statischen Seiten ohne Kundendaten und Zugang zu den Diensten), an Sumsub (Vereinigtes Königreich) und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen). Übermittlungen durch die unten genannten Social-Media-Anbieter sind in Abschnitt 10 beschrieben.
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -180,7 +180,7 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie nur an Cloudflare (USA, Zugang zu den Diensten) sowie an die oben genannten Auftragsverarbeiter. Zusätzlich können im Rahmen von Banktransaktionen Kundendaten an beteiligte Banken im In- und Ausland übermittelt werden (siehe Allgemeine Geschäftsbedingungen).
+Personenbezogene Daten werden in der Schweiz verarbeitet. Ausserhalb der Schweiz gelangen sie an Cloudflare (USA, Zugang zu den Diensten), an die oben genannten Auftragsverarbeiter und im Rahmen von Banktransaktionen an beteiligte Banken (siehe Allgemeine Geschäftsbedingungen).
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -452,7 +452,7 @@ Verweise und Links auf Websites Dritter liegen ausserhalb der Verantwortung von 
 Alle von DFX in digitaler oder elektronischer Form veröffentlichten Angebote sind freibleibend. DFX behält es sich ausdrücklich vor, Teile der Seiten oder das gesamte Angebot ohne gesonderte Ankündigung zu verändern, zu ergänzen, zu löschen oder die Veröffentlichung zeitweise oder endgültig einzustellen.
 
 
-## 16. Urheberrechte und Geistiges Eigentum 
+## 16. Urheberrechte und Geistiges Eigentum
 
 Das Urheberrecht und alle anderen Rechte an den Inhalten, Bildern, Fotos oder anderen Dateien auf der DFX-Website gehören ausschliesslich DFX und den mit ihr verbundenen Unternehmen, deren Lieferanten oder den namentlich genannten Rechtsinhabern.
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -134,7 +134,6 @@ Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacy
 Soweit zur Vertragserfüllung oder zur Erfüllung gesetzlicher Pflichten erforderlich, setzen wir folgende Auftragsverarbeiter ein:
 
 * Sumsub (Sum and Substance Ltd., Vereinigtes Königreich) — gesetzlich vorgeschriebene Identitätsprüfung, einschliesslich Ausweisdokumenten und biometrischer Daten. Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG). Biometrische Daten verarbeiten wir nur mit Ihrer ausdrücklichen Einwilligung (Art. 6 Abs. 7 DSG).
-* Sift Science, Inc. (USA) — Betrugsprävention. Übermittlung gestützt auf das Swiss-U.S. Data Privacy Framework bzw. Standardvertragsklauseln (Art. 16 Abs. 2 lit. d DSG).
 * Dilisense (EU) — Prüfung gegen Sanktions- und PEP-Listen. Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG).
 
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -134,7 +134,7 @@ Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowi
 Soweit zur Vertragserfüllung oder zur Erfüllung gesetzlicher Pflichten erforderlich, setzen wir folgende Auftragsverarbeiter ein:
 
 * Sumsub (Sum and Substance Ltd., Vereinigtes Königreich) — gesetzlich vorgeschriebene Identitätsprüfung, einschliesslich Ausweisdokumenten und biometrischer Daten. Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG). Biometrische Daten verarbeiten wir nur mit Ihrer ausdrücklichen Einwilligung (Art. 6 Abs. 7 DSG).
-* Dilisense (EU) — Prüfung gegen Sanktions- und PEP-Listen. Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG).
+* Dilisense (Schweiz) — Prüfung gegen Sanktions- und PEP-Listen.
 
 
 ## 6. Allgemeine Hinweise und Pflichtinformationen

--- a/src/de/tnc.md
+++ b/src/de/tnc.md
@@ -145,9 +145,9 @@ Bei Blockchaintransaktionen von DFX an nicht self-hosted Wallets werden diese Da
 ## Benutzer-Registrierung
 Bevor die Finanzdienstleistungen von DFX genutzt werden können, muss sich der Kunde registrieren. Die Registrierung ist für Privatpersonen kostenlos und führt nach Anerkennung der aktuellen Allgemeinen Geschäftsbedingungen zur Erstellung eines Nutzerprofils. Wenn sich ein Kunde registriert, hängen die Informationen und Dokumente, die der Kunde an DFX übermitteln muss, und der maximale Betrag, für den der Kunde Kryptowährungen kaufen oder verkaufen kann, von seiner Identifikationsstufe ab:
 
-Die Registrierung erfolgt grundsätzlich über die Blockchain-Adresse unter Angabe der E-Mail oder Telefonnummer des Kunden. Diese Registrierung gilt als Standard – light KYC (Know-Your-Customer) – und erlaubt dem Kunden den Kauf/Verkauf von Kryptowährungen bis zu einem festgelegten Tageslimit. 
+Die Registrierung erfolgt grundsätzlich über die Blockchain-Adresse unter Angabe der E-Mail oder Telefonnummer des Kunden. Diese Registrierung gilt als Standard – light KYC (Know-Your-Customer) – und erlaubt dem Kunden den Kauf/Verkauf von Kryptowährungen bis zu einem festgelegten Monatslimit (rollierender 30-Tage-Zeitraum).
 
-Für den Kauf/Verkauf von Kryptowährungen überhalb dieses Tageslimits bedarf es einer detaillierteren Registrierung, welche als Erweiterter – voller KYC (Know-Your-Customer) – Prozess gilt. Im Rahmen dieses Prozesses sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
+Für den Kauf/Verkauf von Kryptowährungen oberhalb dieses Monatslimits bedarf es einer detaillierteren Registrierung, welche als Erweiterter – voller KYC (Know-Your-Customer) – Prozess gilt. Im Rahmen dieses Prozesses sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
 
 * Adresse, wobei deren Nachweis über die Zustellung eines Briefes an die angegebene Adresse erfolgt
 * Kopie des Ausweisdokuments (Personalausweis oder Reisepass), das eine Unterschrift, einen lesbaren MRZ-Code und ein Foto aufweisen muss
@@ -216,7 +216,7 @@ Verkaufsrouten können storniert werden, solange die umzuwandelnde Kryptowährun
 
 Die Transaktionskosten der Krypto- respektive Fremdwährungen, die an den Kunden übermittelt werden, sind im Basispreis enthalten. Die Preise verstehen sich in der für die Transaktion zulässigen Kryptowährung und beinhalten die Schweizer Mehrwertsteuer, falls zutreffend. Nachdem die Überweisung der gewünschten Kryptowährung respektive der gewünschten Fremdwährung auf die/das Wallet/Konto des Kunden erfolgt ist, gilt der Verkauf als abgeschlossen. Der Kunde erhält per E-Mail eine Bestätigung des Transaktionsabschlusses unter Angabe einer Transaktionsübersicht.
 
-DFX weist darauf hin, dass pro Tag und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert. 
+DFX weist darauf hin, dass pro Monat (rollierender 30-Tage-Zeitraum) und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert. 
 
 Rückbuchungen von Verkäufen an Kunden der DFX erfolgen ausschliesslich in der ursprünglich transferierten Kryptowährung. Der zurückerstattete Betrag entspricht genau dem Wert, der zum Verkauf an DFX übertragen wurde.
 
@@ -238,7 +238,7 @@ Hierbei gelten folgende Bestimmungen:
   * Technische Manipulationen, um DFX über die Bezahlung zu täuschen, sind nicht gestattet und werden zur Anzeige gebracht. Insbesondere sind „doppelte Ausgaben“ (Double Spending) nicht erlaubt und werden als Betrug strafrechtlich verfolgt.
 
 DFX bietet hierbei die Bezahlung mittels folgender Standards an:
-* FrankencoinPay und OpenCryptoPay
+* OpenCryptoPay
   * Zahlungen über Lightning BOLT11
     * Der Nutzer trägt die Routing-Gebühr.
     * Ein erhaltener Beitrag von zum Beispiel 1 BTC entspricht 1 BTC.

--- a/src/de/tnc.md
+++ b/src/de/tnc.md
@@ -142,9 +142,9 @@ Bei Blockchaintransaktionen von DFX an nicht self-hosted Wallets werden diese Da
 ## Benutzer-Registrierung
 Bevor die Finanzdienstleistungen von DFX genutzt werden können, muss sich der Kunde registrieren. Die Registrierung ist für Privatpersonen kostenlos und führt nach Anerkennung der aktuellen Allgemeinen Geschäftsbedingungen zur Erstellung eines Nutzerprofils. Wenn sich ein Kunde registriert, hängen die Informationen und Dokumente, die der Kunde an DFX übermitteln muss, und der maximale Betrag, für den der Kunde Kryptowährungen kaufen oder verkaufen kann, von seiner Identifikationsstufe ab:
 
-Die Registrierung erfolgt grundsätzlich über die Blockchain-Adresse unter Angabe der E-Mail oder Telefonnummer des Kunden. Diese Registrierung gilt als Standard – light KYC (Know-Your-Customer) – und erlaubt dem Kunden den Kauf/Verkauf von Kryptowährungen bis zu einem festgelegten Tageslimit. 
+Die Registrierung erfolgt grundsätzlich über die Blockchain-Adresse unter Angabe der E-Mail oder Telefonnummer des Kunden. Diese Registrierung gilt als Standard – light KYC (Know-Your-Customer) – und erlaubt dem Kunden den Kauf/Verkauf von Kryptowährungen bis zu einem festgelegten Monatslimit (rollierender 30-Tage-Zeitraum).
 
-Für den Kauf/Verkauf von Kryptowährungen überhalb dieses Tageslimits bedarf es einer detaillierteren Registrierung, welche als Erweiterter – voller KYC (Know-Your-Customer) – Prozess gilt. Im Rahmen dieses Prozesses sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
+Für den Kauf/Verkauf von Kryptowährungen oberhalb dieses Monatslimits bedarf es einer detaillierteren Registrierung, welche als Erweiterter – voller KYC (Know-Your-Customer) – Prozess gilt. Im Rahmen dieses Prozesses sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
 
 * Adresse, wobei deren Nachweis über die Zustellung eines Briefes an die angegebene Adresse erfolgt
 * Kopie des Ausweisdokuments (Personalausweis oder Reisepass), das eine Unterschrift, einen lesbaren MRZ-Code und ein Foto aufweisen muss
@@ -213,7 +213,7 @@ Verkaufsrouten können storniert werden, solange die umzuwandelnde Kryptowährun
 
 Die Transaktionskosten der Krypto- respektive Fremdwährungen, die an den Kunden übermittelt werden, sind im Basispreis enthalten. Die Preise verstehen sich in der für die Transaktion zulässigen Kryptowährung und beinhalten die Schweizer Mehrwertsteuer, falls zutreffend. Nachdem die Überweisung der gewünschten Kryptowährung respektive der gewünschten Fremdwährung auf die/das Wallet/Konto des Kunden erfolgt ist, gilt der Verkauf als abgeschlossen. Der Kunde erhält per E-Mail eine Bestätigung des Transaktionsabschlusses unter Angabe einer Transaktionsübersicht.
 
-DFX weist darauf hin, dass pro Tag und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert. 
+DFX weist darauf hin, dass pro Monat (rollierender 30-Tage-Zeitraum) und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert. 
 
 Rückbuchungen von Verkäufen an Kunden der DFX erfolgen ausschliesslich in der ursprünglich transferierten Kryptowährung. Der zurückerstattete Betrag entspricht genau dem Wert, der zum Verkauf an DFX übertragen wurde.
 
@@ -237,7 +237,7 @@ Hierbei gelten folgende Bestimmungen:
   * Technische Manipulationen, um DFX über die Bezahlung zu täuschen, sind nicht gestattet und werden zur Anzeige gebracht. Insbesondere sind „doppelte Ausgaben“ (Double Spending) nicht erlaubt und werden als Betrug strafrechtlich verfolgt.
 
 DFX bietet hierbei die Bezahlung mittels folgender Standards an:
-* FrankencoinPay und OpenCryptoPay
+* OpenCryptoPay
   * Zahlungen über Lightning BOLT11
     * Der Nutzer trägt die Routing-Gebühr.
     * Ein erhaltener Beitrag von zum Beispiel 1 BTC entspricht 1 BTC.

--- a/src/de/tnc.md
+++ b/src/de/tnc.md
@@ -213,7 +213,7 @@ Verkaufsrouten können storniert werden, solange die umzuwandelnde Kryptowährun
 
 Die Transaktionskosten der Krypto- respektive Fremdwährungen, die an den Kunden übermittelt werden, sind im Basispreis enthalten. Die Preise verstehen sich in der für die Transaktion zulässigen Kryptowährung und beinhalten die Schweizer Mehrwertsteuer, falls zutreffend. Nachdem die Überweisung der gewünschten Kryptowährung respektive der gewünschten Fremdwährung auf die/das Wallet/Konto des Kunden erfolgt ist, gilt der Verkauf als abgeschlossen. Der Kunde erhält per E-Mail eine Bestätigung des Transaktionsabschlusses unter Angabe einer Transaktionsübersicht.
 
-DFX weist darauf hin, dass pro Monat (rollierender 30-Tage-Zeitraum) und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert. 
+DFX weist darauf hin, dass pro Monat (rollierender 30-Tage-Zeitraum) und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert.
 
 Rückbuchungen von Verkäufen an Kunden der DFX erfolgen ausschliesslich in der ursprünglich transferierten Kryptowährung. Der zurückerstattete Betrag entspricht genau dem Wert, der zum Verkauf an DFX übertragen wurde.
 
@@ -262,5 +262,5 @@ DFX bietet hierbei die Bezahlung mittels folgender Standards an:
 Die Gebühren für Inkasso-Geschäfte sind wie folgt festgelegt:
 * DFX erhebt grundsätzlich keine Gebühren für die Begleichung der Inkasso-Forderungen.
 * DFX definiert eine Blockchain-Adresse, an die der geforderte Betrag übermittelt werden kann. Bei Zahlungen über Lightning wird eine BOLT11-Rechnung erstellt. Die Kosten für die Blockchain-Gebühren oder die Lightning-Routing-Gebühren müssen vom Nutzer übernommen werden und sind nicht Teil der Inkasso-Dienstleistung von DFX. Diese Gebühren sind variabel.
-* Sollte sich der Nutzer entscheiden, in einer Fremdwährung zu bezahlen, berechnet DFX eine Währungsumrechnungsgebühr von 1 %, wenn FrankencoinPay, Lightning BOLT11 oder OpenCryptoPay.io als Zahlungsmethode gewählt wird.  
+* Sollte sich der Nutzer entscheiden, in einer Fremdwährung zu bezahlen, berechnet DFX eine Währungsumrechnungsgebühr von 1 %, wenn Lightning BOLT11 oder OpenCryptoPay.io als Zahlungsmethode gewählt wird.
 Bei allen anderen Zahlungsoptionen, wie beispielsweise „PayToBlockchainAddress“, wird eine Währungsumrechnungsgebühr von 2 % erhoben. Die erhöhte Gebühr ist erforderlich, da bei diesen Zahlungsmethoden eine längere Gültigkeitsdauer angeboten wird.

--- a/src/de/tnc.md
+++ b/src/de/tnc.md
@@ -14,7 +14,7 @@ Mit dem Zugriff auf und der Nutzung der Website sowie mit dem Herunterladen von 
 
 ## Keine Beratung
 DFX bietet keine Anlage-, Steuer- oder Rechtsberatung an. Die auf der Website bereitgestellten Informationen dienen lediglich der Information und stellen keine Empfehlungen dar. Kunden treffen ihre Investitionsentscheidungen eigenverantwortlich und tragen die volle Verantwortung für die daraus resultierenden Risiken.  
-Dies gilt für alle von DFX angebotenen Finanzdienstleistungen, die den Kauf, Verkauf, Tausch sowie das Versenden von Kryptowährungen umfassen.  
+Dies gilt für alle von DFX angebotenen Finanzdienstleistungen, die den Kauf, Verkauf und Tausch von Kryptowährungen umfassen.  
 
 Sämtliche Investitionsentscheidungen, welche die Kunden treffen, basieren ausschliesslich auf ihrer eigenen Einschätzung ihrer finanziellen Situation und ihrer Anlageziele. Sie tragen die alleinige Verantwortung für solche Entscheidungen und daraus resultierende Konsequenzen. DFX erbringt ihre Dienstleistungen ausschliesslich auf ausdrücklichen, eigenständigen Wunsch des Kunden, ohne dessen wirtschaftliche Situation, technisches Verständnis, Eignung oder die Angemessenheit der Investition zu überprüfen.
 
@@ -65,7 +65,6 @@ Die Finanzdienstleistungen von DFX umfassen:
 * Buy (Kaufen)
 * Sell (Verkaufen)
 * Swap (Tauschen)
-* Send (Senden)
 
 Die Payment-Optionen umfassen:
 * Banküberweisung
@@ -94,17 +93,6 @@ Bitte sehen Sie davon ab, direkt die Bank zu kontaktieren, da dies zu erhebliche
 ## Lokale Beschränkungen
 
 Die auf dieser Website angebotenen Produkte und Dienstleistungen sind ausschliesslich in der Schweiz zum Verkauf zugelassen. Personen, die aus dem Ausland auf die Website zugreifen, tun dies auf eigene Verantwortung. DFX lehnt jegliche Verantwortung im Zusammenhang mit der Nutzung der Website ausserhalb der Schweiz ab. Insbesondere wird darauf aufmerksam gemacht, dass jeder ausländische Nutzer selbst verpflichtet ist, abzuklären, ob er die von DFX angebotenen Dienstleistungen und Produkte gestützt auf die geltenden Gesetzgebungen an seinem Wohnsitz respektive Sitz, oder gestützt auf die Gesetzgebungen seines Heimatstaats nutzen darf.
-
-## Verwahrung von Vermögenswerten
-### Konditionen der Verwahrung
-DFX bietet die Verwahrung von Vermögenswerten für Kunden an. Dabei kommen unter anderem folgende Assetklassen infrage: Schweizer Franken (CHF), Euro (EUR), Bitcoin (BTC) und Frankencoin Pool Shares (FPS). Die Verwahrung dieser Assets unterliegt den nachfolgenden Bedingungen:
-* Flexibilität bei der Wahl des Verwahrungsassets: Wenn ein Kunde sich entscheidet, eine bestimmte Menge einer Assetklasse bei DFX zu verwahren, liegt es im Ermessen von DFX, zu entscheiden, in welcher Art oder auf welcher Blockchain dieses Asset aufbewahrt wird.
-    * Beispiel 1: Entscheidet sich der Kunde für die Verwahrung von BTC, kann DFX dieses entweder auf der Bitcoin Mainchain oder als Wrapped Bitcoin (WBTC) auf der Ethereum-Blockchain aufbewahren.
-    * Beispiel 2: Wählt der Kunde FPS, kann dies entweder als FPS auf Ethereum oder als WFPS (Wrapped FPS) auf Polygon verwahrt werden.  
-
-DFX behält sich diese Flexibilität vor, um die Verwahrung effizient und sicher zu gestalten. Alle Assets, die für Kunden gehalten werden, werden segregiert auf einer kundenspezifischen Adresse aufbewahrt. Kunden haben die Möglichkeit, über die [Softwarelösung von DFX](https://app.dfx.swiss/) jederzeit einzusehen, über welche Adresse ihre Vermögenswerte in welcher Art (Asset und Blockchain) verwahrt werden.
-
-Die Verwahrung erfolgt unter Einhaltung der geltenden Schweizer Vorschriften, insbesondere im Hinblick auf die Sicherheit und den Schutz der Kundengelder. DFX stellt sicher, dass die verwahrten Assets nicht mit eigenen Vermögenswerten vermischt werden. Die verwahrten Assets stehen immer im Eigentum des Kunden und würden im Falle einer Insolvenz nicht in die Konkursmasse fallen.
 
 ## Umgang mit Transaktionsdaten
 Bei allen Transaktionen von digitalen Vermögenswerten werden folgende Informationen öffentlich zur Verfügung gestellt:
@@ -140,11 +128,7 @@ Es werden wenigstens folgende Informationen benötigt:
 Bei Blockchaintransaktionen von DFX an nicht self-hosted Wallets werden diese Daten von DFX automatisch an den Hosting Provider übermittelt. Wenn nichts anderes vereinbart ist, werden die Daten per E-Mail an compliance(at)"provider.domain" übermittelt. Kunden von DFX, die dieser Übermittlung nicht zustimmen wollen, empfehlen wir die Nutzung einer self-hosted Wallet.
 
 ## Benutzer-Registrierung
-Bevor die Finanzdienstleistungen von DFX genutzt werden können, muss sich der Kunde registrieren. Die Registrierung ist für Privatpersonen kostenlos und führt nach Anerkennung der aktuellen Allgemeinen Geschäftsbedingungen zur Erstellung eines Nutzerprofils. Wenn sich ein Kunde registriert, hängen die Informationen und Dokumente, die der Kunde an DFX übermitteln muss, und der maximale Betrag, für den der Kunde Kryptowährungen kaufen oder verkaufen kann, von seiner Identifikationsstufe ab:
-
-Die Registrierung erfolgt grundsätzlich über die Blockchain-Adresse unter Angabe der E-Mail oder Telefonnummer des Kunden. Diese Registrierung gilt als Standard – light KYC (Know-Your-Customer) – und erlaubt dem Kunden den Kauf/Verkauf von Kryptowährungen bis zu einem festgelegten Monatslimit (rollierender 30-Tage-Zeitraum).
-
-Für den Kauf/Verkauf von Kryptowährungen oberhalb dieses Monatslimits bedarf es einer detaillierteren Registrierung, welche als Erweiterter – voller KYC (Know-Your-Customer) – Prozess gilt. Im Rahmen dieses Prozesses sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
+Bevor die Finanzdienstleistungen von DFX genutzt werden können, muss sich der Kunde registrieren und die Identitätsprüfung (KYC) abschliessen. Die Registrierung ist für Privatpersonen kostenlos und führt nach Anerkennung der aktuellen Allgemeinen Geschäftsbedingungen zur Erstellung eines Nutzerprofils. Kauf, Verkauf und Tausch sind erst nach abgeschlossener Identitätsprüfung möglich. Im Rahmen der Identitätsprüfung sind insbesondere folgende Informationen gegenüber DFX offenzulegen:
 
 * Adresse, wobei deren Nachweis über die Zustellung eines Briefes an die angegebene Adresse erfolgt
 * Kopie des Ausweisdokuments (Personalausweis oder Reisepass), das eine Unterschrift, einen lesbaren MRZ-Code und ein Foto aufweisen muss
@@ -158,9 +142,9 @@ Bis zu welchen Limits die Käufe/Verkäufe von Kryptowährungen ausgeführt werd
 
 DFX behält sich das Recht vor, eine Videokonferenz zur Überprüfung der Identität des Kunden durchzuführen. Dies gilt unter anderem, wenn DFX der Ansicht ist, dass die zur Verfügung gestellten Unterlagen unvollständig sind, sich der Wohn- oder Geschäftssitz des Kunden in einem Risikoland befindet, oder die erste seitens des Kunden getätigte Transaktion aus einem Risikoland oder über ein Bankkonto, welches nicht auf den Namen des Kunden lautet, erfolgt ist.
 
-Die vollständige und korrekte Vorlage und Validierung dieser Dokumente ist für den erstmaligen Kauf und Verkauf von Kryptowährungen sowie für die Umrechnung von Kryptowährungen, oder auf jederzeitiges Verlangen von DFX ohne Angabe von Gründen, erforderlich.
+Die vollständige und korrekte Vorlage und Validierung dieser Dokumente ist für den Kauf, Verkauf und Tausch von Kryptowährungen erforderlich.
 
-Die angegebenen Daten müssen vollständig und jederzeit gültig sein. Änderungen personenbezogener Daten sowie aller dem light oder vollen KYC zugrunde liegenden Daten sind durch die Kunden an DFX unverzüglich mitzuteilen.
+Die angegebenen Daten müssen vollständig und jederzeit gültig sein. Änderungen personenbezogener Daten sowie aller dem KYC zugrunde liegenden Daten sind durch die Kunden an DFX unverzüglich mitzuteilen.
 
 Mitarbeiter von DFX fragen den Kunden niemals nach Passwörtern, Privatkeys oder Seeds. Solche Anfragen sind zu ignorieren und DFX zu melden.
 
@@ -216,51 +200,3 @@ Die Transaktionskosten der Krypto- respektive Fremdwährungen, die an den Kunden
 DFX weist darauf hin, dass pro Monat (rollierender 30-Tage-Zeitraum) und pro Kunde ein maximales Verkaufsvolumen besteht. Der Kunde hat die Möglichkeit, ein höheres Verkaufsvolumen zu beantragen. Diese Anfrage wird von DFX individuell beurteilt und diskutiert.
 
 Rückbuchungen von Verkäufen an Kunden der DFX erfolgen ausschliesslich in der ursprünglich transferierten Kryptowährung. Der zurückerstattete Betrag entspricht genau dem Wert, der zum Verkauf an DFX übertragen wurde.
-
-## Referral-Programm
-Unser Referral-Programm zahlt Kunden 0,25 % auf das Transaktionsvolumen, das über den Referral-Link des Kunden von einem neuen Kunden generiert wird, sowie 0,1 % auf Payment-Link-Transaktionen. 
-
-Es wird darauf hingewiesen, dass die Teilnahme am Referral-Programm ausschliesslich für DFX-Kunden gestattet ist. Zudem kann das Referral-Programm jederzeit und ohne Ankündigung eingestellt oder verändert werden. Weitere Details sind unter https://app.dfx.swiss/account einsehbar. Es wird darauf hingewiesen, dass dieser Link nur funktioniert, wenn der Nutzer sich bereits mit seinem Kundenaccount angemeldet hat.
-
-Das Referral-Programm richtet sich an in der Schweiz wohnhafte Kunden und ist für Empfehlungen im persönlichen Umfeld bestimmt. Es begründet kein Vertretungs-, Vermittlungs- oder Auftragsverhältnis. Der Kunde ist nicht berechtigt, im Namen von DFX aufzutreten oder Erklärungen abzugeben. Eine öffentliche oder bezahlte/gesponserte Bewerbung oder Verbreitung des Referral-Codes bzw. der Dienstleistungen von DFX (z.B. über Websites oder Social Media) ist nicht zulässig. Der Kunde nimmt zur Kenntnis, dass eine Weitergabe oder Bewerbung ausserhalb der Schweiz gegen lokale Vorschriften verstossen kann. Bei Verdacht oder Nachweis eines Verstosses kann DFX die Teilnahme sperren sowie Vorteile oder Vergütungen verweigern oder zurückfordern. Der Kunde ersetzt DFX den Schaden aus schuldhafter Verletzung dieser Bestimmung, einschliesslich angemessener Rechtskosten. Behördliche Bussen oder Strafen ersetzt der Kunde nur, soweit dies gesetzlich zulässig ist und sie unmittelbar durch sein schuldhaftes Verhalten verursacht wurden.
-
-## Inkasso-Geschäft
-
-## Umfang und Bestimmungen des Inkasso-Geschäfts
-Das Inkasso-Geschäft von DFX umfasst:
-* Payment-Link
-
-Hierbei gelten folgende Bestimmungen: 
-* Vertragsparteien, die Forderungen an DFX per Inkasso-Geschäft abtreten möchten, müssen dies mittels eines gesonderten Vertrags mit DFX vereinbaren. Sofern im Vertrag nichts anderes geregelt ist, gelten Gebühren von 0,1 % auf den Umsatz.
-* Nutzer, die sich entscheiden, eine ausstehende Forderung über den DFX-Inkasso-Service zu begleichen, können dies gemäss den folgenden Bedingungen tun:
-  * Jede Forderung hat eine definierte Gültigkeitsdauer, die in UTC angegeben ist. Die Zahlung muss innerhalb dieser Frist erfolgen.
-  * Technische Manipulationen, um DFX über die Bezahlung zu täuschen, sind nicht gestattet und werden zur Anzeige gebracht. Insbesondere sind „doppelte Ausgaben“ (Double Spending) nicht erlaubt und werden als Betrug strafrechtlich verfolgt.
-
-DFX bietet hierbei die Bezahlung mittels folgender Standards an:
-* OpenCryptoPay
-  * Zahlungen über Lightning BOLT11
-    * Der Nutzer trägt die Routing-Gebühr.
-    * Ein erhaltener Beitrag von zum Beispiel 1 BTC entspricht 1 BTC.
-  * Zahlungen auf einer EVM-basierten Blockchain
-    * Der Nutzer trägt die Blockchain-Gebühr.
-    * Ein erhaltener Beitrag von zum Beispiel 1 ZCHF entspricht 1 ZCHF.
-  * Zahlungen auf einer UTXO-basierten Blockchain
-    * Der Nutzer trägt die Blockchain-Gebühr.
-    * Ein erhaltener Beitrag von zum Beispiel 1 BTC entspricht nicht 1 BTC.
-      * Die Kosten für den Empfang von einem UTXO werden dem Absender zusätzlich verrechnet, da DFX das empfangene UTXO nur dann ausgeben kann, wenn die entsprechende Blockchain-Transaktionsgebühr bezahlt wird.
-      * Die DFX betrachtet daher den technisch erhaltenen Betrag abzüglich der aktuellen Blockchain-Transaktionsgebühr als den effektiv erhaltenen Betrag.
-
-* Zahlungen über Lightning BOLT11
-    * analog zu oben
-
-* PayToBlockchainAddress
-  * Zahlungen auf einer EVM-basierten Blockchain
-    * analog zu oben
-  * Zahlungen auf einer UTXO-basierten Blockchain
-    * analog zu oben
-
-Die Gebühren für Inkasso-Geschäfte sind wie folgt festgelegt:
-* DFX erhebt grundsätzlich keine Gebühren für die Begleichung der Inkasso-Forderungen.
-* DFX definiert eine Blockchain-Adresse, an die der geforderte Betrag übermittelt werden kann. Bei Zahlungen über Lightning wird eine BOLT11-Rechnung erstellt. Die Kosten für die Blockchain-Gebühren oder die Lightning-Routing-Gebühren müssen vom Nutzer übernommen werden und sind nicht Teil der Inkasso-Dienstleistung von DFX. Diese Gebühren sind variabel.
-* Sollte sich der Nutzer entscheiden, in einer Fremdwährung zu bezahlen, berechnet DFX eine Währungsumrechnungsgebühr von 1 %, wenn Lightning BOLT11 oder OpenCryptoPay.io als Zahlungsmethode gewählt wird.
-Bei allen anderen Zahlungsoptionen, wie beispielsweise „PayToBlockchainAddress“, wird eine Währungsumrechnungsgebühr von 2 % erhoben. Die erhöhte Gebühr ist erforderlich, da bei diesen Zahlungsmethoden eine längere Gültigkeitsdauer angeboten wird.

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -42,13 +42,97 @@ You have the right to receive information about the origin, recipient and purpos
 
 You can contact our [Support](https://services.dfx.swiss/support) at any time with regard to this and other questions on the subject of data protection.
 
-## 3. Hosting
+## 3. Hosting and infrastructure
 
-### Hosting with All-Inkl
+### API and application platform with Microsoft Azure
 
-We host our website with All-Inkl. The provider is ALL-INKL.COM - Neue Medien Münnich, owner René Münnich, Hauptstraße 68, 02742 Friedersdorf (hereinafter: All-Inkl). Details can be found in the [privacy policy of All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+The core infrastructure of DFX — in particular the API (api.dfx.swiss), the application platform (app.dfx.swiss) and the database — is operated on Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). All personal data processed in connection with the use of our financial services (including customer data, transaction data, KYC data and identity documents) is stored and processed on Azure infrastructure.
 
-## 4. General notes and mandatory information
+DFX uses Azure App Services, Azure Storage, Azure CDN and a Microsoft SQL Server database. Data processing takes place in European Azure data centres. Microsoft has implemented appropriate technical and organisational measures to ensure the protection of personal data. Data transfers to the USA (where applicable) are based on the Swiss-US Data Privacy Framework and standard contractual clauses pursuant to Art. 16(2)(d) FADP.
+
+For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement) and the [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+
+### Information website with All-Inkl
+
+The information website (dfx.swiss) and the documentation site (docs.dfx.swiss) are hosted by All-Inkl. The provider is ALL-INKL.COM - Neue Medien Münnich, owner René Münnich, Hauptstrasse 68, 02742 Friedersdorf, Germany (hereinafter: All-Inkl). No personal customer data is processed on these sites.
+
+Details can be found in the [privacy policy of All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+
+
+## 4. Data processors and third-party providers
+
+DFX uses various external data processors to provide its services. These process personal data exclusively on behalf of and on the instructions of DFX. DFX ensures through contractual agreements that all data processors maintain an adequate level of data protection.
+
+### Identity verification (KYC) with Sumsub
+
+For the legally required identity verification (Know Your Customer, KYC), DFX uses the service provider Sumsub (Sum and Substance Ltd., England and Wales, Company No. 09688671) as a data processor.
+
+#### Data processed
+
+The following personal data is transmitted to and processed by Sumsub as part of the identity verification:
+
+* Personal details: first name, surname, date of birth, nationality
+* Address: street, house number, postcode, city, country
+* Identity documents: passport, identity card or other official identity documents (copies/photos)
+* Biometric data: facial images (selfies), facial recognition and liveness detection to verify identity
+* Video recordings: as part of video identification (if required)
+
+#### Particularly sensitive data (Art. 5(c) FADP)
+
+The biometric data processed as part of the identity verification (facial geometry, liveness detection) is classified as particularly sensitive personal data within the meaning of Art. 5(c) FADP. The processing of this data takes place exclusively on the basis of your express consent pursuant to Art. 6(7) FADP, which you provide separately before the start of the identification process. You may revoke this consent at any time with effect for the future; however, revocation will mean that the identity verification cannot be completed and certain DFX services cannot be used.
+
+#### Data transfer abroad
+
+Sumsub is based in England and Wales (United Kingdom). The United Kingdom has an adequacy decision from the Swiss Federal Council pursuant to Art. 16(1) FADP, ensuring an adequate level of data protection without the need for additional safeguards.
+
+#### Retention period
+
+Documents and biometric data collected as part of the identity verification are stored by DFX for the legally required retention period of 10 years after termination of the business relationship (Art. 7 AMLA). Raw biometric data at Sumsub is deleted in accordance with contractual agreements after the verification is completed.
+
+For further information on data protection at Sumsub, please refer to the [Sumsub Privacy Notice](https://sumsub.com/privacy-notice-service/).
+
+### Fraud prevention with Sift
+
+DFX uses the service provider Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) as a data processor for fraud prevention and anti-money laundering.
+
+#### Data processed
+
+The following data is transmitted to Sift as part of fraud prevention:
+
+* Account information: user ID, creation date, KYC level
+* Transaction data: amount, currency, payment method (last 4 digits of credit card or first 6 and last 4 digits of IBAN), blockchain address
+* Technical data: IP address, device information, browser type
+* Login data: time and type of login
+
+#### Data transfer abroad
+
+Sift is based in the USA. Data transfer is based on the Swiss-US Data Privacy Framework, insofar as Sift is certified under this framework, or on standard contractual clauses pursuant to Art. 16(2)(d) FADP.
+
+For further information, please refer to the [Sift Privacy Notice](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Sanctions screening with Dilisense
+
+DFX uses the service provider Dilisense to screen customers against sanctions lists, PEP lists (politically exposed persons) and criminal records. As part of this screening, the customer's name, date of birth and nationality are transmitted.
+
+### Server-side monitoring with Azure Application Insights
+
+DFX uses Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) for the purpose of operational monitoring, error detection and performance optimisation of the API infrastructure. Application Insights is not a website analytics tool for tracking user behaviour, but a server-side monitoring tool.
+
+#### Data processed
+
+* Technical request data: URL paths, HTTP status codes, response times
+* Error and exception logs: stack traces, error messages
+* Dependencies: calls to databases and external services
+* IP addresses: as part of request processing
+
+No personal content (such as names, addresses or financial data) is transmitted to Application Insights.
+
+#### Data transfer abroad
+
+Microsoft may process data in data centres outside Switzerland (EU/USA). Data transfer is based on standard contractual clauses pursuant to Art. 16(2)(d) FADP and the Swiss-US Data Privacy Framework. For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement).
+
+
+## 5. General notes and mandatory information
 
 ### Storage period
 
@@ -60,7 +144,17 @@ The website only stores and processes the minimum data required to operate the w
 
 ### Note on the transfer of data abroad
 
-We use the hosting service All-Inkl, a company from Germany. When these tools are accessed, your personal data is transferred to this third country and could be processed there.
+In the course of our business activities, personal data is transferred to recipients in the following countries:
+
+| Recipient | Country | Purpose | Legal basis |
+|-----------|---------|---------|-------------|
+| Microsoft Corporation (Azure) | EU / USA | Hosting of API, database, app platform, monitoring | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
+| Sumsub (Sum and Substance Ltd.) | United Kingdom | Identity verification (KYC) | Adequacy decision (Art. 16(1) FADP) |
+| Sift Science, Inc. | USA | Fraud prevention | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
+| Dilisense | EU | Sanctions and PEP screening | Adequacy decision (Art. 16(1) FADP) |
+| All-Inkl (ALL-INKL.COM - Neue Medien Münnich) | Germany (EU) | Hosting of information website (no customer data) | Adequacy decision (Art. 16(1) FADP) |
+
+DFX only transfers personal data to countries that have an adequate level of data protection (pursuant to Annex 1 of the Data Protection Ordinance) or subject to appropriate safeguards such as standard contractual clauses (Art. 16(2)(d) FADP). In addition, customer data may be transferred to participating banks in Switzerland and abroad in the context of bank transactions (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 
@@ -84,7 +178,7 @@ The above rights may be denied or restricted if the interests, rights and freedo
 
 We hereby object to the use of contact data published as part of our obligation to provide a legal notice for the purpose of sending unsolicited advertising and information material. The operators of the website expressly reserve the right to take legal action in the event of the unsolicited sending of advertising information, such as spam e-mails.
 
-## 5. Data collection on this website
+## 6. Data collection on this website
 
 ### Cookies
 
@@ -96,11 +190,13 @@ If you contact us by e-mail, telephone or fax, we will store and process your en
 
 The data you send to us via contact requests will remain with us until you ask us to delete it, revoke your consent to storage or the purpose for data storage no longer applies (for example, after your request has been processed). Mandatory statutory provisions - in particular statutory retention periods - remain unaffected.
 
-## 6 Analysis tools and advertising
+## 8. Analysis tools and advertising
 
-DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others.
+DFX does not use website analytics tools for tracking user behaviour, such as Google Analytics, Adobe Analytics or comparable services. No tracking pixels, advertising cookies or similar technologies for analysing user behaviour are used.
 
-## 7. Newsletter and social media
+For server-side operational monitoring of the API infrastructure, DFX uses Microsoft Azure Application Insights (see Section 4 "Data processors and third-party providers"). This tool is used exclusively for technical monitoring, error detection and performance optimisation and does not collect any data on user behaviour on the website.
+
+## 9. Newsletter and social media
 
 ### Newsletter data
 
@@ -174,7 +270,7 @@ The data transfer to the USA is based on the standard contractual clauses of the
 
 Details on how they handle your personal data can be found in the [LinkedIn Privacy Policy](https://www.linkedin.com/legal/privacy-policy).
 
-## 8 Data protection for applications and in the application process
+## 10. Data protection for applications and in the application process
 The controller collects and processes the personal data of applicants for the purpose of carrying out the application process. This processing may also take place electronically, in particular if applicants also send relevant application documents by e-mail (for example in PDF format or other file types).
 
 If you apply for a job advertised by us, these data protection provisions apply in addition to our other data protection provisions, which have been communicated to you separately or are available on our website.
@@ -185,29 +281,29 @@ If the person responsible for processing concludes an employment contract with a
 
 If no employment contract is concluded, the application documents will be deleted automatically and without further notification 12 months after notification of the rejection decision, provided that no other legitimate interests of the data processing centre prevent deletion. Legitimate interests can be, for example, obligations to provide evidence in proceedings under the Swiss Equal Treatment Act (GlG).
 
-## 9 Applicable law and place of jurisdiction
+## 11. Applicable law and place of jurisdiction
 The DFX website with its registered office in Switzerland is governed exclusively by Swiss (data protection) law, unless other mandatory law, in particular the EU General Data Protection Regulation (GDPR), is applicable to the natural person concerned.
 
 The court at the registered office of DFX (Switzerland) shall have exclusive jurisdiction for any disputes between you as a visitor and user of the DFX website arising from the operation of or visit to the websites, unless another mandatory place of jurisdiction is applicable to the natural person concerned.
 
-## 10 Changes to the privacy policy
+## 12. Changes to the privacy policy
 DFX regularly reviews this Privacy policy to ensure that it is always up to date and reserves the right to amend it as necessary. It is recommended that you check this page regularly for possible changes, as no individual notification of changes will be made.  
 In the event of discrepancies with the English version, the German version of this privacy policy shall prevail.
 
-## 11 Legal information and disclaimer
+## 13. Legal information and disclaimer
 DFX accepts no liability for the accuracy and completeness of the content of the information.
 
 Liability claims relating to material or immaterial damage caused by the use or non-use of the information provided or by the use of incorrect or incomplete information are fundamentally excluded.
 
 All offers published by DFX in digital or electronic form are subject to change. DFX expressly reserves the right to change, supplement or delete parts of the pages or the entire offer without prior notice or to cease publication temporarily or permanently.
 
-## 12 Liability for links
+## 14. Liability for links
 DFX is not responsible for references and links to third-party websites. Any responsibility for websites of third parties, i.e., outside the companies belonging to DFX, is rejected. Access to and use of such websites is at the user's own risk.
 
 All offers published by DFX in digital or electronic form are subject to change. DFX expressly reserves the right to change, supplement or delete parts of the pages or the entire offer without prior notice or to cease publication temporarily or permanently.
 
-## 13 Copyrights and intellectual property 
+## 15. Copyrights and intellectual property 
 The copyright and all other rights to the content, images, photos or other files on the DFX website belong exclusively to DFX and its affiliated companies, their suppliers or the specifically named rights holders.
 
-## 14 Consent to the privacy policy
+## 16. Consent to the privacy policy
 The customer accepts the content of the data protection declaration in its current version in full. In the event of contradictions, the Privacy policy takes precedence over the General Terms and Conditions of DFX.

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -134,7 +134,7 @@ When you access them, technically necessary data (in particular your IP address 
 Where required to perform the contract or to comply with legal obligations, we use the following data processors:
 
 * Sumsub (Sum and Substance Ltd., United Kingdom) — legally required identity verification, including identity documents and biometric data. The United Kingdom is covered by an adequacy decision (Art. 16(1) FADP). We process biometric data only with your explicit consent (Art. 6(7) FADP).
-* Dilisense (EU) — screening against sanctions and PEP lists. Adequacy decision (Art. 16(1) FADP).
+* Dilisense (Switzerland) — screening against sanctions and PEP lists.
 
 
 ## 6. General notes and mandatory information

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -249,7 +249,7 @@ The data you send to us via contact requests will remain with us until you ask u
 
 ## 9. Analysis tools and advertising
 
-DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others. No tracking pixels, advertising cookies or similar technologies for analysing user behaviour are used.
+DFX does not use website analysis tools for tracking user behaviour, such as Google Analytics, Adobe Analytics or comparable services. No tracking pixels, advertising cookies or similar technologies for analysing user behaviour are used.
 
 
 ## 10. Newsletter and social media

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -180,7 +180,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-Personal data is processed in Switzerland. Outside Switzerland it is transmitted only to Cloudflare (USA, access to the services) and to the data processors named above. In addition, customer data may be transferred to participating banks in Switzerland and abroad in the context of bank transactions (see General Terms and Conditions).
+Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -452,7 +452,7 @@ References and links to third-party websites are outside the responsibility of D
 All offers published by DFX in digital or electronic form are subject to change. DFX expressly reserves the right to change, supplement or delete parts of the pages or the entire offer without prior notice or to cease publication temporarily or permanently.
 
 
-## 16. Copyrights and intellectual property 
+## 16. Copyrights and intellectual property
 
 The copyright and all other rights to the content, images, photos or other files on the DFX website belong exclusively to DFX and its affiliated companies, their suppliers or the specifically named rights holders.
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -180,7 +180,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static pages without customer data and access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
+Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static pages without customer data and access to the services), to Sumsub (United Kingdom) and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -122,11 +122,11 @@ Data subjects have the right to object to profiling and to request information a
 
 ## 4. Hosting and infrastructure
 
-DFX operates the API, the application platform and the database on its own servers in Switzerland.
+DFX hosts static websites that do not collect customer data (such as dfx.swiss) with Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
 
-Public access to our websites and services is provided through Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) as a content delivery network and reverse proxy. When you access them, technically necessary data (in particular your IP address and request metadata) is transmitted to Cloudflare.
+DFX operates the API, the application platform and the database on its own servers in Switzerland. Public access to these services is provided through Cloudflare as a content delivery network and reverse proxy.
 
-Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and the Swiss-U.S. Data Privacy Framework. In addition, we rely on standard contractual clauses (Art. 16(2)(d) FADP). Details: [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) and [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
+When you access them, technically necessary data (in particular your IP address and request metadata) is transmitted to Cloudflare. Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and the Swiss-U.S. Data Privacy Framework. In addition, we rely on standard contractual clauses (Art. 16(2)(d) FADP). Details: [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) and [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Data processors
@@ -180,7 +180,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
+Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static websites and access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -224,7 +224,7 @@ In the event of a data protection violation that is likely to result in a high r
 
 * Notification of the competent supervisory authority (FDPIC) as soon as possible after becoming aware of the breach (Art. 24(1) FADP).
 * Notification of the data subjects, if this is necessary for their protection or if the FDPIC so requires (Art. 24(4) FADP), without delay and in clear, understandable language.
-* DFX's data processors (such as Sumsub, Sift and others) are contractually obliged to inform DFX immediately of data protection breaches (Art. 24(3) FADP).
+* The data processors named above are contractually obliged to inform DFX immediately of data protection breaches (Art. 24(3) FADP).
    
 ### Protective measures
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -120,7 +120,7 @@ DFX does not carry out purely automated decision-making processes that are legal
 Data subjects have the right to object to profiling and to request information about the underlying logic and the effects of profiling on them.
 
 
-## 4. Hosting
+## 4. Hosting and infrastructure
 
 ### Hosting with Cloudflare Pages
 
@@ -128,8 +128,89 @@ We host our website with Cloudflare Pages. The provider is Cloudflare, Inc., 101
 
 Cloudflare has implemented appropriate technical and organizational measures to ensure the protection of personal data. Details on their handling of personal data can be found in the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). Processing on our behalf is governed by the [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
+### API and application platform with Microsoft Azure
 
-## 5. General notes and mandatory information
+The core infrastructure of DFX — in particular the API (api.dfx.swiss), the application platform (app.dfx.swiss) and the database — is operated on Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). All personal data processed in connection with the use of our financial services (including customer data, transaction data, KYC data and identity documents) is stored and processed on Azure infrastructure.
+
+DFX uses Azure App Services, Azure Storage, Azure CDN and a Microsoft SQL Server database. Data processing takes place in European Azure data centres. Microsoft has implemented appropriate technical and organisational measures to ensure the protection of personal data. Data transfers to the USA (where applicable) are based on the Swiss-US Data Privacy Framework and standard contractual clauses pursuant to Art. 16(2)(d) FADP.
+
+For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement) and the [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+
+
+## 5. Data processors and third-party providers
+
+DFX uses various external data processors to provide its services. These process personal data exclusively on behalf of and on the instructions of DFX. DFX ensures through contractual agreements that all data processors maintain an adequate level of data protection.
+
+### Identity verification (KYC) with Sumsub
+
+For the legally required identity verification (Know Your Customer, KYC), DFX uses the service provider Sumsub (Sum and Substance Ltd., England and Wales, Company No. 09688671) as a data processor.
+
+#### Data processed
+
+The following personal data is transmitted to and processed by Sumsub as part of the identity verification:
+
+* Personal details: first name, surname, date of birth, nationality
+* Address: street, house number, postcode, city, country
+* Identity documents: passport, identity card or other official identity documents (copies/photos)
+* Biometric data: facial images (selfies), facial recognition and liveness detection to verify identity
+* Video recordings: as part of video identification (if required)
+
+#### Particularly sensitive data (Art. 5(c) FADP)
+
+The biometric data processed as part of the identity verification (facial geometry, liveness detection) is classified as particularly sensitive personal data within the meaning of Art. 5(c) FADP. The processing of this data takes place exclusively on the basis of your express consent pursuant to Art. 6(7) FADP, which you provide separately before the start of the identification process. You may revoke this consent at any time with effect for the future; however, revocation will mean that the identity verification cannot be completed and certain DFX services cannot be used.
+
+#### Data transfer abroad
+
+Sumsub is based in England and Wales (United Kingdom). The United Kingdom has an adequacy decision from the Swiss Federal Council pursuant to Art. 16(1) FADP, ensuring an adequate level of data protection without the need for additional safeguards.
+
+#### Retention period
+
+Documents and biometric data collected as part of the identity verification are stored by DFX for the legally required retention period of 10 years after termination of the business relationship (Art. 7 AMLA). Raw biometric data at Sumsub is deleted in accordance with contractual agreements after the verification is completed.
+
+For further information on data protection at Sumsub, please refer to the [Sumsub Privacy Notice](https://sumsub.com/privacy-notice-service/).
+
+### Fraud prevention with Sift
+
+DFX uses the service provider Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) as a data processor for fraud prevention and anti-money laundering.
+
+#### Data processed
+
+The following data is transmitted to Sift as part of fraud prevention:
+
+* Account information: user ID, creation date, KYC level
+* Transaction data: amount, currency, payment method (last 4 digits of credit card or first 6 and last 4 digits of IBAN), blockchain address
+* Technical data: IP address, device information, browser type
+* Login data: time and type of login
+
+#### Data transfer abroad
+
+Sift is based in the USA. Data transfer is based on the Swiss-US Data Privacy Framework, insofar as Sift is certified under this framework, or on standard contractual clauses pursuant to Art. 16(2)(d) FADP.
+
+For further information, please refer to the [Sift Privacy Notice](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Sanctions screening with Dilisense
+
+DFX uses the service provider Dilisense to screen customers against sanctions lists, PEP lists (politically exposed persons) and criminal records. As part of this screening, the customer's name, date of birth and nationality are transmitted.
+
+### Server-side monitoring with Azure Application Insights
+
+DFX uses Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) for the purpose of operational monitoring, error detection and performance optimisation of the API infrastructure. Application Insights is not a website analytics tool for tracking user behaviour, but a server-side monitoring tool.
+
+#### Data processed
+
+* Technical request data: URL paths, HTTP status codes, response times
+* Error and exception logs: stack traces, error messages
+* Dependencies: calls to databases and external services
+* IP addresses: as part of request processing
+
+No personal content (such as names, addresses or financial data) is transmitted to Application Insights.
+
+#### Data transfer abroad
+
+Microsoft may process data in data centres outside Switzerland (EU/USA). Data transfer is based on standard contractual clauses pursuant to Art. 16(2)(d) FADP and the Swiss-US Data Privacy Framework. For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement).
+
+
+## 6. General notes and mandatory information
 
 ### Storage period
 
@@ -176,6 +257,18 @@ For hosting we use Cloudflare Pages, a service provided by Cloudflare, Inc. base
 
 Legal basis for the data transfer to the USA: Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and under the Swiss-U.S. Data Privacy Framework. In addition, we rely on the EU Commission's Standard Contractual Clauses. Despite these safeguards, access by U.S. authorities (e.g., under the CLOUD Act) cannot be entirely excluded.
 
+In the course of our business activities, personal data is transferred to recipients in the following countries:
+
+| Recipient | Country | Purpose | Legal basis |
+|-----------|---------|---------|-------------|
+| Microsoft Corporation (Azure) | EU / USA | Hosting of API, database, app platform, monitoring | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
+| Sumsub (Sum and Substance Ltd.) | United Kingdom | Identity verification (KYC) | Adequacy decision (Art. 16(1) FADP) |
+| Sift Science, Inc. | USA | Fraud prevention | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
+| Dilisense | EU | Sanctions and PEP screening | Adequacy decision (Art. 16(1) FADP) |
+| Cloudflare, Inc. | USA | Hosting of website and documentation (Cloudflare Pages) | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
+
+DFX only transfers personal data to countries that have an adequate level of data protection (pursuant to Annex 1 of the Data Protection Ordinance) or subject to appropriate safeguards such as standard contractual clauses (Art. 16(2)(d) FADP). In addition, customer data may be transferred to participating banks in Switzerland and abroad in the context of bank transactions (see General Terms and Conditions).
+
 ### SSL or TLS encryption
 
 For security reasons and to protect the transmission of confidential content, such as inquiries that you send to us as the site operator, this site uses SSL or TLS encryption. You can recognize an encrypted connection by the fact that the address line of the browser changes from "http://" to "https://" and by the lock symbol in your browser line.
@@ -199,7 +292,7 @@ The above rights may be denied or restricted if the interests, rights and freedo
 We hereby object to the use of contact data published as part of the imprint obligation for sending unsolicited advertising and information material. The operators of the pages expressly reserve the right to take legal action in the event of the unsolicited sending of advertising information, such as spam emails.
 
 
-## 6. Data protection violations
+## 7. Data protection violations
 
 DFX takes data protection violations very seriously and has implemented processes to handle such incidents efficiently and in accordance with legal requirements. A data protection violation occurs when personal data is unintentionally or unlawfully disclosed, altered, deleted or made accessible without authorization.
 
@@ -215,8 +308,9 @@ In the event of a data protection violation, DFX follows a structured procedure 
 
 In the event of a data protection violation that poses a risk to the rights and freedoms of data subjects, DFX is legally obliged to inform certain parties. These notifications are intended to ensure that both the competent authorities and the data subjects are informed in a timely manner about the violation and the measures taken. The notifications are made in compliance with legal requirements and include the following steps:
 
-* Notification of the supervisory authority within 72 hours of becoming aware of the violation.
-* Notification of the data subjects without delay and in clear, understandable language.
+* Notification of the competent supervisory authority (FDPIC) as soon as possible after becoming aware of the breach (Art. 24(1) FADP).
+* Notification of the data subjects, if this is necessary for their protection or if the FDPIC so requires (Art. 24(4) FADP), without delay and in clear, understandable language.
+* DFX's data processors (such as Sumsub, Sift and others) are contractually obliged to inform DFX immediately of data protection breaches (Art. 24(3) FADP).
    
 ### Protective measures
 
@@ -227,7 +321,7 @@ To prevent data protection violations, we use technical and organizational measu
 If you notice a possible data protection violation, please contact our [Support](https://services.dfx.swiss/support).
 
 
-## 7. Data collection on this website
+## 8. Data collection on this website
 
 ### Cookies
 
@@ -240,12 +334,14 @@ If you contact us by email, telephone or fax, your inquiry including all persona
 The data you send to us via contact requests will remain with us until you ask us to delete it, revoke your consent to storage or the purpose for data storage no longer applies (e.g., after your request has been processed). Mandatory statutory provisions - in particular statutory retention periods - remain unaffected.
 
 
-## 8. Analysis tools and advertising
+## 9. Analysis tools and advertising
 
 DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others.
 
+For server-side operational monitoring of the API infrastructure, DFX uses Microsoft Azure Application Insights (see Section 5 "Data processors and third-party providers"). This tool is used exclusively for technical monitoring, error detection and performance optimisation and does not collect any data on user behaviour on the website.
 
-## 9. Newsletter and social media
+
+## 10. Newsletter and social media
 
 ### Newsletter data
 
@@ -314,7 +410,7 @@ Data transfer to the USA is based on the standard contractual clauses of the EU 
 Details on how they handle your personal data can be found in the [LinkedIn Privacy Policy](https://www.linkedin.com/legal/privacy-policy).
 
 
-## 10. Data protection for applications and in the application process
+## 11. Data protection for applications and in the application process
 
 The controller collects and processes the personal data of applicants for the purpose of carrying out the application process. This processing may also take place electronically, in particular if applicants also send relevant application documents by email (e.g., in PDF format or other file types).
 
@@ -327,20 +423,20 @@ If the controller concludes an employment contract with an applicant, the data t
 If no employment contract is concluded, the application documents will be automatically deleted 12 months after notification of the rejection decision without further notification, provided that no other legitimate interests of the data processing center prevent deletion. Legitimate interests may be, for example, obligations to provide evidence in proceedings under the Equal Treatment Act (GlG).
 
 
-## 11. Applicable law and jurisdiction
+## 12. Applicable law and jurisdiction
 
 The DFX website with its registered office in Switzerland is governed exclusively by Swiss (data protection) law, unless other mandatory law is applicable to the natural person concerned.
 
 The court at the registered office of DFX (Switzerland) shall have exclusive jurisdiction for any disputes between you as a visitor and user of the DFX website arising from the operation of or visit to the websites, unless another mandatory place of jurisdiction is applicable to the natural person concerned.
 
 
-## 12. Changes to the privacy policy
+## 13. Changes to the privacy policy
 
 DFX regularly reviews this privacy policy to ensure that it is always up to date and reserves the right to amend it as necessary. It is recommended that you check this page regularly for possible changes, as no individual notification of changes will be made.  
 In the event of discrepancies with the English version, the German version of this privacy policy shall prevail.
 
 
-## 13. Legal information and disclaimer
+## 14. Legal information and disclaimer
 
 DFX accepts no liability for the accuracy and completeness of the content of the information.
 
@@ -349,19 +445,19 @@ Liability claims relating to material or immaterial damage caused by the use or 
 All offers published by DFX in digital or electronic form are subject to change. DFX expressly reserves the right to change, supplement or delete parts of the pages or the entire offer without prior notice or to cease publication temporarily or permanently.
 
 
-## 14. Liability for links
+## 15. Liability for links
 
 References and links to third-party websites are outside the responsibility of DFX. Any responsibility for websites of third parties, i.e., outside the companies belonging to DFX, is rejected. Access to and use of such websites is at the user's own risk.
 
 All offers published by DFX in digital or electronic form are subject to change. DFX expressly reserves the right to change, supplement or delete parts of the pages or the entire offer without prior notice or to cease publication temporarily or permanently.
 
 
-## 15. Copyrights and intellectual property 
+## 16. Copyrights and intellectual property 
 
 The copyright and all other rights to the content, images, photos or other files on the DFX website belong exclusively to DFX and its affiliated companies, their suppliers or the specifically named rights holders.
 
 
-## 16. Consent to the privacy policy
+## 17. Consent to the privacy policy
 
 The customer accepts the content of the privacy policy in its current version in full. In the event of contradictions, the privacy policy takes precedence over the General Terms and Conditions of DFX.
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -122,9 +122,9 @@ Data subjects have the right to object to profiling and to request information a
 
 ## 4. Hosting and infrastructure
 
-DFX hosts static websites that do not collect customer data (such as dfx.swiss) with Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
+DFX hosts static information pages that do not collect customer data (such as dfx.swiss) with Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Those pages have no customer accounts, no transactions and no identity verification.
 
-DFX operates the API, the application platform and the database on its own servers in Switzerland. Public access to these services is provided through Cloudflare as a content delivery network and reverse proxy.
+Everything that processes customer data — the API, the application platform and the database — is operated by DFX on its own servers in Switzerland. Public access to these services is provided through Cloudflare as a content delivery network and reverse proxy.
 
 When you access them, technically necessary data (in particular your IP address and request metadata) is transmitted to Cloudflare. Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and the Swiss-U.S. Data Privacy Framework. In addition, we rely on standard contractual clauses (Art. 16(2)(d) FADP). Details: [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) and [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static websites and access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
+Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static pages without customer data and access to the services), to the data processors named above and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -124,7 +124,7 @@ Data subjects have the right to object to profiling and to request information a
 
 DFX hosts static information pages that do not collect customer data (such as dfx.swiss) with Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Those pages have no customer accounts, no transactions and no identity verification.
 
-Everything that processes customer data — the API, the application platform and the database — is operated by DFX on its own servers in Switzerland. Public access to these services is provided through Cloudflare as a content delivery network and reverse proxy.
+DFX operates the API, the application platform and the database on its own servers in Switzerland. Public access to these services is provided through Cloudflare as a content delivery network and reverse proxy.
 
 When you access them, technically necessary data (in particular your IP address and request metadata) is transmitted to Cloudflare. Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and the Swiss-U.S. Data Privacy Framework. In addition, we rely on standard contractual clauses (Art. 16(2)(d) FADP). Details: [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) and [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-Personal data is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static pages without customer data and access to the services), to Sumsub (United Kingdom) and, in the context of bank transactions, to participating banks (see General Terms and Conditions).
+Customer data of the trading platform is processed in Switzerland. Outside Switzerland it is transmitted to Cloudflare (USA, hosting of the static pages without customer data and access to the services), to Sumsub (United Kingdom) and, in the context of bank transactions, to participating banks (see General Terms and Conditions). Transfers by the social media providers named below are described in section 10.
 
 ### SSL or TLS encryption
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -306,7 +306,7 @@ In the event of a data protection violation, DFX follows a structured procedure 
 
 #### Notification obligations
 
-In the event of a data protection violation that poses a risk to the rights and freedoms of data subjects, DFX is legally obliged to inform certain parties. These notifications are intended to ensure that both the competent authorities and the data subjects are informed in a timely manner about the violation and the measures taken. The notifications are made in compliance with legal requirements and include the following steps:
+In the event of a data protection violation that is likely to result in a high risk to the personality or fundamental rights of the data subjects, DFX is legally obliged to inform certain parties. These notifications are intended to ensure that both the competent authorities and the data subjects are informed in a timely manner about the violation and the measures taken. The notifications are made in compliance with legal requirements and include the following steps:
 
 * Notification of the competent supervisory authority (FDPIC) as soon as possible after becoming aware of the breach (Art. 24(1) FADP).
 * Notification of the data subjects, if this is necessary for their protection or if the FDPIC so requires (Art. 24(4) FADP), without delay and in clear, understandable language.
@@ -336,7 +336,7 @@ The data you send to us via contact requests will remain with us until you ask u
 
 ## 9. Analysis tools and advertising
 
-DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others.
+DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others. No tracking pixels, advertising cookies or similar technologies for analysing user behaviour are used.
 
 For server-side operational monitoring of the API infrastructure, DFX uses Microsoft Azure Application Insights (see Section 5 "Data processors and third-party providers"). This tool is used exclusively for technical monitoring, error detection and performance optimisation and does not collect any data on user behaviour on the website.
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -122,92 +122,20 @@ Data subjects have the right to object to profiling and to request information a
 
 ## 4. Hosting and infrastructure
 
-### Hosting with Cloudflare Pages
+DFX operates the API, the application platform and the database on its own servers in Switzerland.
 
-We host our website with Cloudflare Pages. The provider is Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (hereinafter: Cloudflare).
+Public access to our websites and services is provided through Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) as a content delivery network and reverse proxy. When you access them, technically necessary data (in particular your IP address and request metadata) is transmitted to Cloudflare.
 
-Cloudflare has implemented appropriate technical and organizational measures to ensure the protection of personal data. Details on their handling of personal data can be found in the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). Processing on our behalf is governed by the [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
-
-### API and application platform with Microsoft Azure
-
-The core infrastructure of DFX — in particular the API (api.dfx.swiss), the application platform (app.dfx.swiss) and the database — is operated on Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). All personal data processed in connection with the use of our financial services (including customer data, transaction data, KYC data and identity documents) is stored and processed on Azure infrastructure.
-
-DFX uses Azure App Services, Azure Storage, Azure CDN and a Microsoft SQL Server database. Data processing takes place in European Azure data centres. Microsoft has implemented appropriate technical and organisational measures to ensure the protection of personal data. Data transfers to the USA (where applicable) are based on the Swiss-US Data Privacy Framework and standard contractual clauses pursuant to Art. 16(2)(d) FADP.
-
-For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement) and the [Microsoft Online Services Terms](https://www.microsoft.com/licensing/terms).
+Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and the Swiss-U.S. Data Privacy Framework. In addition, we rely on standard contractual clauses (Art. 16(2)(d) FADP). Details: [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) and [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
-## 5. Data processors and third-party providers
+## 5. Data processors
 
-DFX uses various external data processors to provide its services. These process personal data exclusively on behalf of and on the instructions of DFX. DFX ensures through contractual agreements that all data processors maintain an adequate level of data protection.
+Where required to perform the contract or to comply with legal obligations, we use the following data processors:
 
-### Identity verification (KYC) with Sumsub
-
-For the legally required identity verification (Know Your Customer, KYC), DFX uses the service provider Sumsub (Sum and Substance Ltd., England and Wales, Company No. 09688671) as a data processor.
-
-#### Data processed
-
-The following personal data is transmitted to and processed by Sumsub as part of the identity verification:
-
-* Personal details: first name, surname, date of birth, nationality
-* Address: street, house number, postcode, city, country
-* Identity documents: passport, identity card or other official identity documents (copies/photos)
-* Biometric data: facial images (selfies), facial recognition and liveness detection to verify identity
-* Video recordings: as part of video identification (if required)
-
-#### Particularly sensitive data (Art. 5(c) FADP)
-
-The biometric data processed as part of the identity verification (facial geometry, liveness detection) is classified as particularly sensitive personal data within the meaning of Art. 5(c) FADP. The processing of this data takes place exclusively on the basis of your express consent pursuant to Art. 6(7) FADP, which you provide separately before the start of the identification process. You may revoke this consent at any time with effect for the future; however, revocation will mean that the identity verification cannot be completed and certain DFX services cannot be used.
-
-#### Data transfer abroad
-
-Sumsub is based in England and Wales (United Kingdom). The United Kingdom has an adequacy decision from the Swiss Federal Council pursuant to Art. 16(1) FADP, ensuring an adequate level of data protection without the need for additional safeguards.
-
-#### Retention period
-
-Documents and biometric data collected as part of the identity verification are stored by DFX for the legally required retention period of 10 years after termination of the business relationship (Art. 7 AMLA). Raw biometric data at Sumsub is deleted in accordance with contractual agreements after the verification is completed.
-
-For further information on data protection at Sumsub, please refer to the [Sumsub Privacy Notice](https://sumsub.com/privacy-notice-service/).
-
-### Fraud prevention with Sift
-
-DFX uses the service provider Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) as a data processor for fraud prevention and anti-money laundering.
-
-#### Data processed
-
-The following data is transmitted to Sift as part of fraud prevention:
-
-* Account information: user ID, creation date, KYC level
-* Transaction data: amount, currency, payment method (last 4 digits of credit card or first 6 and last 4 digits of IBAN), blockchain address
-* Technical data: IP address, device information, browser type
-* Login data: time and type of login
-
-#### Data transfer abroad
-
-Sift is based in the USA. Data transfer is based on the Swiss-US Data Privacy Framework, insofar as Sift is certified under this framework, or on standard contractual clauses pursuant to Art. 16(2)(d) FADP.
-
-For further information, please refer to the [Sift Privacy Notice](https://sift.com/legal-and-compliance/service-privacy-notice).
-
-### Sanctions screening with Dilisense
-
-DFX uses the service provider Dilisense to screen customers against sanctions lists, PEP lists (politically exposed persons) and criminal records. As part of this screening, the customer's name, date of birth and nationality are transmitted.
-
-### Server-side monitoring with Azure Application Insights
-
-DFX uses Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) for the purpose of operational monitoring, error detection and performance optimisation of the API infrastructure. Application Insights is not a website analytics tool for tracking user behaviour, but a server-side monitoring tool.
-
-#### Data processed
-
-* Technical request data: URL paths, HTTP status codes, response times
-* Error and exception logs: stack traces, error messages
-* Dependencies: calls to databases and external services
-* IP addresses: as part of request processing
-
-No personal content (such as names, addresses or financial data) is transmitted to Application Insights.
-
-#### Data transfer abroad
-
-Microsoft may process data in data centres outside Switzerland (EU/USA). Data transfer is based on standard contractual clauses pursuant to Art. 16(2)(d) FADP and the Swiss-US Data Privacy Framework. For further information, please refer to the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement).
+* Sumsub (Sum and Substance Ltd., United Kingdom) — legally required identity verification, including identity documents and biometric data. The United Kingdom is covered by an adequacy decision (Art. 16(1) FADP). We process biometric data only with your explicit consent (Art. 6(7) FADP).
+* Sift Science, Inc. (USA) — fraud prevention. Transfers are based on the Swiss-U.S. Data Privacy Framework or standard contractual clauses (Art. 16(2)(d) FADP).
+* Dilisense (EU) — screening against sanctions and PEP lists. Adequacy decision (Art. 16(1) FADP).
 
 
 ## 6. General notes and mandatory information
@@ -253,21 +181,7 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-For hosting we use Cloudflare Pages, a service provided by Cloudflare, Inc. based in the USA. When you access our website, technically necessary data (in particular your IP address and request metadata) is transferred to the USA and processed there, as Cloudflare terminates the connection as a reverse proxy / content delivery network.
-
-Legal basis for the data transfer to the USA: Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and under the Swiss-U.S. Data Privacy Framework. In addition, we rely on the EU Commission's Standard Contractual Clauses. Despite these safeguards, access by U.S. authorities (e.g., under the CLOUD Act) cannot be entirely excluded.
-
-In the course of our business activities, personal data is transferred to recipients in the following countries:
-
-| Recipient | Country | Purpose | Legal basis |
-|-----------|---------|---------|-------------|
-| Microsoft Corporation (Azure) | EU / USA | Hosting of API, database, app platform, monitoring | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
-| Sumsub (Sum and Substance Ltd.) | United Kingdom | Identity verification (KYC) | Adequacy decision (Art. 16(1) FADP) |
-| Sift Science, Inc. | USA | Fraud prevention | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
-| Dilisense | EU | Sanctions and PEP screening | Adequacy decision (Art. 16(1) FADP) |
-| Cloudflare, Inc. | USA | Hosting of website and documentation (Cloudflare Pages) | Swiss-US DPF / Standard contractual clauses (Art. 16(2) FADP) |
-
-DFX only transfers personal data to countries that have an adequate level of data protection (pursuant to Annex 1 of the Data Protection Ordinance) or subject to appropriate safeguards such as standard contractual clauses (Art. 16(2)(d) FADP). In addition, customer data may be transferred to participating banks in Switzerland and abroad in the context of bank transactions (see General Terms and Conditions).
+Personal data is processed in Switzerland. Outside Switzerland it is transmitted only to Cloudflare (USA, access to the services) and to the data processors named above. In addition, customer data may be transferred to participating banks in Switzerland and abroad in the context of bank transactions (see General Terms and Conditions).
 
 ### SSL or TLS encryption
 
@@ -337,8 +251,6 @@ The data you send to us via contact requests will remain with us until you ask u
 ## 9. Analysis tools and advertising
 
 DFX does not use website analysis tools such as Google Analytics, Adobe Analytics or others. No tracking pixels, advertising cookies or similar technologies for analysing user behaviour are used.
-
-For server-side operational monitoring of the API infrastructure, DFX uses Microsoft Azure Application Insights (see Section 5 "Data processors and third-party providers"). This tool is used exclusively for technical monitoring, error detection and performance optimisation and does not collect any data on user behaviour on the website.
 
 
 ## 10. Newsletter and social media

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -134,7 +134,6 @@ Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.d
 Where required to perform the contract or to comply with legal obligations, we use the following data processors:
 
 * Sumsub (Sum and Substance Ltd., United Kingdom) — legally required identity verification, including identity documents and biometric data. The United Kingdom is covered by an adequacy decision (Art. 16(1) FADP). We process biometric data only with your explicit consent (Art. 6(7) FADP).
-* Sift Science, Inc. (USA) — fraud prevention. Transfers are based on the Swiss-U.S. Data Privacy Framework or standard contractual clauses (Art. 16(2)(d) FADP).
 * Dilisense (EU) — screening against sanctions and PEP lists. Adequacy decision (Art. 16(1) FADP).
 
 

--- a/src/en/tnc.md
+++ b/src/en/tnc.md
@@ -145,9 +145,9 @@ For blockchain transactions from DFX to non-self-hosted wallets, this data is au
 ## User Registration
 Before using the financial services of DFX, customers must register. Registration is free for individuals and leads to the creation of a user profile upon acceptance of the current Terms and Conditions. When a customer registers, the information and documents they must provide to DFX, as well as the maximum amount for which they can buy or sell cryptocurrencies, depend on their identification level:
 
-Registration is generally carried out via the blockchain address, providing the customer's email or phone number. This registration is considered standard – light KYC (Know-Your-Customer) – and allows the customer to buy/sell cryptocurrencies up to a set daily limit.
+Registration is generally carried out via the blockchain address, providing the customer's email or phone number. This registration is considered standard – light KYC (Know-Your-Customer) – and allows the customer to buy/sell cryptocurrencies up to a set monthly limit (rolling 30-day period).
 
-For buying/selling cryptocurrencies above this daily limit, a more detailed registration is required, which is considered the Extended – full KYC (Know-Your-Customer) process. As part of this process, the following information must be disclosed to DFX:
+For buying/selling cryptocurrencies above this monthly limit, a more detailed registration is required, which is considered the Extended – full KYC (Know-Your-Customer) process. As part of this process, the following information must be disclosed to DFX:
 
 * Address, verified by proof of delivery via mail to the provided address
 * A copy of the identity document (ID card or passport) with a signature, readable MRZ code, and a photo
@@ -216,7 +216,7 @@ Sales routes can be canceled as long as the cryptocurrency to be converted has n
 
 The transaction costs for the crypto or foreign currencies transferred to the customer are included in the base price. The prices are in the cryptocurrency allowed for the transaction and include Swiss VAT, if applicable. Once the transfer of the desired cryptocurrency or foreign currency to the customer’s wallet/account has been completed, the sale is considered final. The customer will receive an email confirmation of the transaction completion, along with a transaction summary.
 
-DFX notes that there is a maximum daily sales volume per customer. The customer can apply for a higher sales volume. This request will be evaluated and discussed individually by DFX.
+DFX notes that there is a maximum monthly sales volume per customer (rolling 30-day period). The customer can apply for a higher sales volume. This request will be evaluated and discussed individually by DFX.
 
 Refunds of sales to DFX customers are made exclusively in the originally transferred cryptocurrency. The refunded amount corresponds exactly to the value that was transferred to DFX.
 
@@ -238,7 +238,7 @@ The following terms apply:
   * Technical manipulations to deceive DFX regarding payment are not permitted and will be reported to the authorities. Specifically, "double spending" is prohibited and will be prosecuted as fraud.
 
 DFX offers payment through the following standards:
-* FrankencoinPay and OpenCryptoPay  
+* OpenCryptoPay
   * Payments via Lightning BOLT11
     * The user bears the routing fee.
     * A received contribution of 1 BTC equals 1 BTC.
@@ -263,5 +263,5 @@ DFX offers payment through the following standards:
 The fees for debt collection transactions are as follows:
 * DFX generally does not charge fees for settling debt collection claims.
 * DFX defines a blockchain address to which the claimed amount can be transferred. For payments via Lightning, a BOLT11 invoice is created. The costs for blockchain fees or Lightning routing fees must be borne by the user and are not part of DFX’s debt collection service. These fees are variable.
-* If the user decides to pay in a foreign currency, DFX will charge a currency conversion fee of 1% when FrankencoinPay, Lightning BOLT11, or OpenCryptoPay.io is used.  
+* If the user decides to pay in a foreign currency, DFX will charge a currency conversion fee of 1% when Lightning BOLT11 or OpenCryptoPay is used.  
 For all other payment options, such as "PayToBlockchainAddress," a currency conversion fee of 2% will be charged. The higher fee is required because these payment methods offer a longer validity period.

--- a/src/en/tnc.md
+++ b/src/en/tnc.md
@@ -262,5 +262,5 @@ DFX offers payment using the following standards:
 The fees for debt collection business are set as follows:
 * DFX generally does not charge any fees for settling debt collection claims.
 * DFX defines a blockchain address to which the claimed amount can be transmitted. For payments via Lightning, a BOLT11 invoice is created. The costs for blockchain fees or Lightning routing fees must be borne by the user and are not part of DFX's debt collection service. These fees are variable.
-* If the user decides to pay in a foreign currency, DFX charges a currency conversion fee of 1% if FrankencoinPay, Lightning BOLT11 or OpenCryptoPay.io is selected as the payment method.  
+* If the user decides to pay in a foreign currency, DFX charges a currency conversion fee of 1% if Lightning BOLT11 or OpenCryptoPay.io is selected as the payment method.
 For all other payment options, such as "PayToBlockchainAddress", a currency conversion fee of 2% is charged. The increased fee is necessary because these payment methods offer a longer validity period.

--- a/src/en/tnc.md
+++ b/src/en/tnc.md
@@ -14,7 +14,7 @@ By accessing and using the website and downloading information, data and documen
 
 ## No advice
 DFX does not provide investment, tax or legal advice. The information provided on the website is for informational purposes only and does not constitute recommendations. Customers make their investment decisions independently and bear full responsibility for the resulting risks.  
-This applies to all financial services offered by DFX, which include the purchase, sale, exchange and sending of cryptocurrencies.  
+This applies to all financial services offered by DFX, which include the purchase, sale and exchange of cryptocurrencies.  
 
 All investment decisions made by customers are based solely on their own assessment of their financial situation and investment goals. They bear sole responsibility for such decisions and the resulting consequences. DFX provides its services exclusively at the explicit, independent request of the customer, without checking their financial situation, technical understanding, suitability or the appropriateness of the investment.
 
@@ -65,7 +65,6 @@ DFX's financial services include:
 * Buy
 * Sell
 * Swap (Exchange)
-* Send
 
 The payment options include:
 * Bank transfer
@@ -94,17 +93,6 @@ Please refrain from contacting the bank directly, as this will result in signifi
 ## Local restrictions
 
 The products and services offered on this website are only approved for sale in Switzerland. Persons accessing the website from abroad do so at their own risk. DFX disclaims any responsibility in connection with the use of the website outside Switzerland. In particular, it is pointed out that every foreign user is obliged to clarify for themselves whether they may use the services and products offered by DFX based on the applicable legislation at their place of residence or registered office, or based on the legislation of their home country.
-
-## Custody of assets
-### Terms of custody
-DFX offers the custody of assets for customers. The following asset classes are eligible for this: Swiss Francs (CHF), Euro (EUR), Bitcoin (BTC) and Frankencoin Pool Shares (FPS). The custody of these assets is subject to the following conditions:
-* Flexibility in the choice of custody asset: If a customer decides to custody a certain amount of an asset class with DFX, it is at DFX's discretion to decide in which type or on which blockchain this asset is held.
-    * Example 1: If the customer decides to custody BTC, DFX can hold this either on the Bitcoin mainchain or as Wrapped Bitcoin (WBTC) on the Ethereum blockchain.
-    * Example 2: If the customer chooses FPS, this can be held either as FPS on Ethereum or as WFPS (Wrapped FPS) on Polygon.  
-
-DFX reserves this flexibility to make custody efficient and secure. All assets held for customers are held segregated on a customer-specific address. Customers have the option to view at any time via the [DFX software solution](https://app.dfx.swiss/) which address their assets are held on and in which type (asset and blockchain).
-
-Custody is carried out in compliance with applicable Swiss regulations, in particular with regard to the security and protection of customer funds. DFX ensures that the assets held are not mixed with its own assets. The assets held are always the property of the customer and would not fall into the bankruptcy estate in the event of insolvency.
 
 ## Handling of transaction data
 For all transactions of digital assets, the following information is made publicly available:
@@ -140,11 +128,7 @@ At least the following information is required:
 For blockchain transactions from DFX to non-self-hosted wallets, this data is automatically transmitted by DFX to the hosting provider. Unless otherwise agreed, the data is transmitted by email to compliance(at)"provider.domain". Customers of DFX who do not wish to agree to this transmission are recommended to use a self-hosted wallet.
 
 ## User registration
-Before DFX's financial services can be used, the customer must register. Registration is free for private individuals and, after acceptance of the current Terms and Conditions, leads to the creation of a user profile. When a customer registers, the information and documents that the customer must submit to DFX and the maximum amount for which the customer can buy or sell cryptocurrencies depend on their identification level:
-
-Registration is generally carried out via the blockchain address, providing the customer's email or telephone number. This registration is considered standard – light KYC (Know-Your-Customer) – and allows the customer to buy/sell cryptocurrencies up to a set monthly limit (rolling 30-day period).
-
-For the purchase/sale of cryptocurrencies above this monthly limit, a more detailed registration is required, which is considered an extended – full KYC (Know-Your-Customer) – process. As part of this process, the following information in particular must be disclosed to DFX:
+Before DFX's financial services can be used, the customer must register and complete identity verification (KYC). Registration is free for private individuals and, after acceptance of the current Terms and Conditions, leads to the creation of a user profile. Buying, selling and exchanging are only possible after identity verification has been completed. As part of the identity verification, the following information in particular must be disclosed to DFX:
 
 * Address, proof of which is provided by delivery of a letter to the specified address
 * Copy of the identification document (ID card or passport), which must have a signature, a readable MRZ code and a photo
@@ -158,9 +142,9 @@ The limits up to which purchases/sales of cryptocurrencies are executed are deci
 
 DFX reserves the right to conduct a video conference to verify the customer's identity. This applies, among other things, if DFX is of the opinion that the documents provided are incomplete, the customer's place of residence or business is located in a risk country, or the first transaction made by the customer was made from a risk country or via a bank account that is not in the customer's name.
 
-The complete and correct submission and validation of these documents is required for the first purchase and sale of cryptocurrencies as well as for the conversion of cryptocurrencies, or at any time upon request by DFX without giving reasons.
+The complete and correct submission and validation of these documents is required for the purchase, sale and exchange of cryptocurrencies.
 
-The data provided must be complete and valid at all times. Changes to personal data as well as all data underlying the light or full KYC must be communicated to DFX by the customer without delay.
+The data provided must be complete and valid at all times. Changes to personal data as well as all data underlying the KYC must be communicated to DFX by the customer without delay.
 
 DFX employees never ask the customer for passwords, private keys or seeds. Such requests should be ignored and reported to DFX.
 
@@ -216,51 +200,3 @@ The transaction costs of the crypto or foreign currencies that are transmitted t
 DFX points out that there is a maximum sales volume per month (rolling 30-day period) and per customer. The customer has the option to apply for a higher sales volume. This request will be assessed and discussed individually by DFX.
 
 Refunds of sales to DFX customers are made exclusively in the originally transferred cryptocurrency. The refunded amount corresponds exactly to the value that was transferred to DFX for sale.
-
-## Referral program
-Our referral program pays customers 0.25% on the purchase/investment volume that was purchased by a new customer via the customer's referral link, as well as 0.1% on payment link transactions. 
-
-It is pointed out that participation in the referral program is only permitted for DFX customers. It is also pointed out that the referral program can be discontinued or changed at any time and without notice. Further details can be viewed at https://app.dfx.swiss/account. It is pointed out that this link only works if the user has already logged in with their customer account.
-
-The referral program is aimed at customers resident in Switzerland and is intended for referrals in the personal environment. It does not establish a representation, mediation or mandate relationship. The customer is not authorized to act on behalf of DFX or make declarations. Public or paid/sponsored advertising or distribution of the referral code or DFX services (e.g., via websites or social media) is not permitted. The customer acknowledges that passing on or advertising outside Switzerland may violate local regulations. In the event of suspicion or proof of a violation, DFX may block participation and refuse or reclaim benefits or remuneration. The customer compensates DFX for damage resulting from culpable violation of this provision, including reasonable legal costs. The customer only compensates for official fines or penalties to the extent that this is legally permissible and they were directly caused by their culpable behavior.
-
-## Debt collection business
-
-## Scope and provisions of the debt collection business
-DFX's debt collection business includes:
-* Payment Link
-
-The following provisions apply: 
-* Contracting parties who wish to assign claims to DFX via debt collection business must agree to this by means of a separate contract with DFX. Unless otherwise stipulated in the contract, fees of 0.1% on turnover apply.
-* Users who decide to settle an outstanding claim via the DFX debt collection service can do so according to the following conditions:
-  * Each claim has a defined validity period, which is specified in UTC. Payment must be made within this period.
-  * Technical manipulations to deceive DFX about payment are not permitted and will be reported. In particular, "double spending" is not permitted and will be prosecuted as fraud.
-
-DFX offers payment using the following standards:
-* OpenCryptoPay
-  * Payments via Lightning BOLT11
-    * The user bears the routing fee.
-    * A received contribution of, for example, 1 BTC corresponds to 1 BTC.
-  * Payments on an EVM-based blockchain
-    * The user bears the blockchain fee.
-    * A received contribution of, for example, 1 ZCHF corresponds to 1 ZCHF.
-  * Payments on a UTXO-based blockchain
-    * The user bears the blockchain fee.
-    * A received contribution of, for example, 1 BTC does not correspond to 1 BTC.
-      * The costs for receiving a UTXO are additionally charged to the sender, as DFX can only spend the received UTXO if the corresponding blockchain transaction fee is paid.
-      * DFX therefore considers the technically received amount minus the current blockchain transaction fee as the effectively received amount.
-
-* Payments via Lightning BOLT11
-    * analogous to above
-
-* PayToBlockchainAddress
-  * Payments on an EVM-based blockchain
-    * analogous to above
-  * Payments on a UTXO-based blockchain
-    * analogous to above
-
-The fees for debt collection business are set as follows:
-* DFX generally does not charge any fees for settling debt collection claims.
-* DFX defines a blockchain address to which the claimed amount can be transmitted. For payments via Lightning, a BOLT11 invoice is created. The costs for blockchain fees or Lightning routing fees must be borne by the user and are not part of DFX's debt collection service. These fees are variable.
-* If the user decides to pay in a foreign currency, DFX charges a currency conversion fee of 1% if Lightning BOLT11 or OpenCryptoPay.io is selected as the payment method.
-For all other payment options, such as "PayToBlockchainAddress", a currency conversion fee of 2% is charged. The increased fee is necessary because these payment methods offer a longer validity period.

--- a/src/en/tnc.md
+++ b/src/en/tnc.md
@@ -142,9 +142,9 @@ For blockchain transactions from DFX to non-self-hosted wallets, this data is au
 ## User registration
 Before DFX's financial services can be used, the customer must register. Registration is free for private individuals and, after acceptance of the current Terms and Conditions, leads to the creation of a user profile. When a customer registers, the information and documents that the customer must submit to DFX and the maximum amount for which the customer can buy or sell cryptocurrencies depend on their identification level:
 
-Registration is generally carried out via the blockchain address, providing the customer's email or telephone number. This registration is considered standard – light KYC (Know-Your-Customer) – and allows the customer to buy/sell cryptocurrencies up to a defined daily limit. 
+Registration is generally carried out via the blockchain address, providing the customer's email or telephone number. This registration is considered standard – light KYC (Know-Your-Customer) – and allows the customer to buy/sell cryptocurrencies up to a set monthly limit (rolling 30-day period).
 
-For the purchase/sale of cryptocurrencies above this daily limit, a more detailed registration is required, which is considered an extended – full KYC (Know-Your-Customer) – process. As part of this process, the following information in particular must be disclosed to DFX:
+For the purchase/sale of cryptocurrencies above this monthly limit, a more detailed registration is required, which is considered an extended – full KYC (Know-Your-Customer) – process. As part of this process, the following information in particular must be disclosed to DFX:
 
 * Address, proof of which is provided by delivery of a letter to the specified address
 * Copy of the identification document (ID card or passport), which must have a signature, a readable MRZ code and a photo
@@ -213,7 +213,7 @@ Sales routes can be cancelled as long as the cryptocurrency to be converted has 
 
 The transaction costs of the crypto or foreign currencies that are transmitted to the customer are included in the base price. The prices are stated in the cryptocurrency permitted for the transaction and include Swiss VAT, if applicable. Once the transfer of the desired cryptocurrency or the desired foreign currency to the customer's wallet/account has been made, the sale is considered complete. The customer receives an email confirmation of the transaction completion with a transaction overview.
 
-DFX points out that there is a maximum sales volume per day and per customer. The customer has the option to apply for a higher sales volume. This request will be assessed and discussed individually by DFX. 
+DFX points out that there is a maximum sales volume per month (rolling 30-day period) and per customer. The customer has the option to apply for a higher sales volume. This request will be assessed and discussed individually by DFX.
 
 Refunds of sales to DFX customers are made exclusively in the originally transferred cryptocurrency. The refunded amount corresponds exactly to the value that was transferred to DFX for sale.
 
@@ -237,7 +237,7 @@ The following provisions apply:
   * Technical manipulations to deceive DFX about payment are not permitted and will be reported. In particular, "double spending" is not permitted and will be prosecuted as fraud.
 
 DFX offers payment using the following standards:
-* FrankencoinPay and OpenCryptoPay
+* OpenCryptoPay
   * Payments via Lightning BOLT11
     * The user bears the routing fee.
     * A received contribution of, for example, 1 BTC corresponds to 1 BTC.

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -32,16 +32,97 @@ Vous pouvez nous contacter à tout moment à ce sujet ou pour toute autre questi
 
 DFX ne collecte pas de données supplémentaires pour évaluer statistiquement le comportement de navigation et n'utilise aucun de ces programmes dits d'analyse.
 
-## 2. Hosting
+## 2. Hébergement et infrastructure
 
-### Hosting avec GitHub
+### API et plateforme applicative avec Microsoft Azure
 
-Nous hébergeons notre site web chez [GitHub](https://github.com/). Pour plus de détails, veuillez consulter le site web de GitHub:
-[GitHub-Nutzungsbedingungen](https://docs.github.com/de/site-policy/github-terms/github-terms-of-service/).  
-[GitHub-Datenschutzerklärung](https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement/).  
+L'infrastructure centrale de DFX — notamment l'API (api.dfx.swiss), la plateforme applicative (app.dfx.swiss) et la base de données — est exploitée sur Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Toutes les données personnelles traitées dans le cadre de l'utilisation de nos services financiers (y compris les données clients, les données de transactions, les données KYC et les documents d'identité) sont stockées et traitées sur l'infrastructure Azure.
+
+DFX utilise Azure App Services, Azure Storage, Azure CDN ainsi qu'une base de données Microsoft SQL Server. Le traitement des données s'effectue dans des centres de données Azure européens. Microsoft a mis en place des mesures techniques et organisationnelles appropriées pour garantir la protection des données personnelles. Le transfert de données vers les USA (le cas échéant) s'effectue sur la base du Swiss-US Data Privacy Framework et des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
+
+Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement) et les [conditions des services en ligne Microsoft](https://www.microsoft.com/licensing/terms).
+
+### Site d'information avec All-Inkl
+
+Le site d'information (dfx.swiss) et le site de documentation (docs.dfx.swiss) sont hébergés chez All-Inkl. Le fournisseur est ALL-INKL.COM - Neue Medien Münnich, Inh. René Münnich, Hauptstrasse 68, 02742 Friedersdorf, Allemagne. Aucune donnée client personnelle n'est traitée sur ces sites.
+
+Pour plus de détails, veuillez consulter la [politique de confidentialité d'All-Inkl](https://all-inkl.com/datenschutzinformationen/).
 
 
-## 3. Informations générales et obligatoires
+## 3. Sous-traitants et prestataires tiers
+
+DFX fait appel à différents sous-traitants externes pour fournir ses services. Ceux-ci traitent les données personnelles exclusivement sur mandat et selon les instructions de DFX. DFX s'assure par des accords contractuels que tous les sous-traitants garantissent un niveau adéquat de protection des données.
+
+### Vérification d'identité (KYC) avec Sumsub
+
+Pour la vérification d'identité légalement requise (Know Your Customer, KYC), DFX fait appel au prestataire Sumsub (Sum and Substance Ltd., Angleterre et Pays de Galles, Company No. 09688671) en tant que sous-traitant.
+
+#### Données traitées
+
+Dans le cadre de la vérification d'identité, les données personnelles suivantes sont transmises à Sumsub et traitées par celui-ci :
+
+* Données personnelles : prénom, nom, date de naissance, nationalité
+* Adresse : rue, numéro, code postal, ville, pays
+* Documents d'identité : passeport, carte d'identité ou autres documents officiels (copies/photos)
+* Données biométriques : images faciales (selfies), reconnaissance faciale et détection de vivacité pour la vérification d'identité
+* Enregistrements vidéo : dans le cadre de l'identification vidéo (si nécessaire)
+
+#### Données particulièrement sensibles (art. 5 let. c LPD)
+
+Les données biométriques traitées dans le cadre de la vérification d'identité (géométrie faciale, détection de vivacité) sont considérées comme des données personnelles particulièrement sensibles au sens de l'art. 5 let. c LPD. Le traitement de ces données s'effectue exclusivement sur la base de votre consentement exprès conformément à l'art. 6 al. 7 LPD, que vous donnez séparément avant le début du processus d'identification. Vous pouvez révoquer ce consentement à tout moment pour l'avenir ; toutefois, une révocation aura pour conséquence que la vérification d'identité ne pourra pas être achevée et que certains services de DFX ne pourront pas être utilisés.
+
+#### Transfert de données à l'étranger
+
+Sumsub a son siège en Angleterre et au Pays de Galles (Royaume-Uni). Le Royaume-Uni dispose d'une décision d'adéquation du Conseil fédéral suisse conformément à l'art. 16 al. 1 LPD, garantissant un niveau adéquat de protection des données sans nécessiter de garanties supplémentaires.
+
+#### Durée de conservation
+
+Les documents et données biométriques collectés dans le cadre de la vérification d'identité sont conservés par DFX pendant la durée légale de conservation de 10 ans après la fin de la relation d'affaires (art. 7 LBA). Les données biométriques brutes chez Sumsub sont supprimées conformément aux accords contractuels après la conclusion de la vérification.
+
+Pour plus d'informations sur la protection des données chez Sumsub, veuillez consulter la [politique de confidentialité de Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Prévention de la fraude avec Sift
+
+DFX fait appel au prestataire Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) en tant que sous-traitant pour la prévention de la fraude et la lutte contre le blanchiment d'argent.
+
+#### Données traitées
+
+Les données suivantes sont transmises à Sift dans le cadre de la prévention de la fraude :
+
+* Informations de compte : identifiant utilisateur, date de création, niveau KYC
+* Données de transactions : montant, devise, moyen de paiement (4 derniers chiffres de la carte de crédit ou 6 premiers et 4 derniers chiffres de l'IBAN), adresse blockchain
+* Données techniques : adresse IP, informations sur l'appareil, type de navigateur
+* Données de connexion : horodatage et type de connexion
+
+#### Transfert de données à l'étranger
+
+Sift a son siège aux USA. Le transfert de données s'effectue sur la base du Swiss-US Data Privacy Framework, dans la mesure où Sift est certifié sous ce cadre, ou sur la base de clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
+
+Pour plus d'informations, veuillez consulter la [politique de confidentialité de Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Contrôle des sanctions avec Dilisense
+
+DFX fait appel au prestataire Dilisense pour la vérification des clients par rapport aux listes de sanctions, aux listes PEP (personnes politiquement exposées) et aux casiers judiciaires. Dans le cadre de ce contrôle, le nom, la date de naissance et la nationalité du client sont transmis.
+
+### Surveillance côté serveur avec Azure Application Insights
+
+DFX utilise Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) à des fins de surveillance opérationnelle, de détection d'erreurs et d'optimisation des performances de l'infrastructure API. Application Insights n'est pas un outil d'analyse de site web pour le suivi du comportement des utilisateurs, mais un outil de surveillance côté serveur.
+
+#### Données traitées
+
+* Données de requêtes techniques : chemins URL, codes de statut HTTP, temps de réponse
+* Journaux d'erreurs et d'exceptions : traces de pile, messages d'erreur
+* Dépendances : appels aux bases de données et services externes
+* Adresses IP : dans le cadre du traitement des requêtes
+
+Aucun contenu personnel (tel que noms, adresses ou données financières) n'est transmis à Application Insights.
+
+#### Transfert de données à l'étranger
+
+Microsoft peut traiter des données dans des centres de données en dehors de la Suisse (UE/USA). Le transfert de données s'effectue sur la base des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD et du Swiss-US Data Privacy Framework. Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement).
+
+
+## 4. Informations générales et obligatoires
 
 ### Confidentialité
 
@@ -72,7 +153,17 @@ Le site Internet DFX.swiss enregistre et traite uniquement les données qui sont
 
 ### Remarque sur la transmission de données à l'étranger
 
-Pour l'hébergement, nous utilisons GitHub, une entreprise située aux États-Unis. Lorsque ces outils sont consultés, vos données personnelles sont transmises à ce pays tiers et pourraient y être traitées. Nous attirons votre attention sur le fait qu'il n'est pas possible de garantir dans ces pays un niveau de protection des données comparable à celui de la Suisse. Par exemple, les entreprises américaines sont obligées de transmettre des données personnelles aux autorités de sécurité sans que vous puissiez, en tant que personne concernée, intenter une action en justice. Il ne peut donc pas être exclu que les autorités américaines (par ex. les services secrets) traitent, évaluent et stockent durablement vos données sur des serveurs américains à des fins de surveillance. Nous n'avons aucune influence sur ces activités de traitement.
+Dans le cadre de nos activités commerciales, des données personnelles sont transmises aux destinataires dans les pays suivants :
+
+| Destinataire | Pays | Finalité | Base juridique |
+|-------------|------|----------|----------------|
+| Microsoft Corporation (Azure) | UE / USA | Hébergement de l'API, base de données, plateforme applicative, surveillance | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
+| Sumsub (Sum and Substance Ltd.) | Royaume-Uni | Vérification d'identité (KYC) | Décision d'adéquation (art. 16 al. 1 LPD) |
+| Sift Science, Inc. | USA | Prévention de la fraude | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
+| Dilisense | UE | Contrôle des sanctions et PEP | Décision d'adéquation (art. 16 al. 1 LPD) |
+| All-Inkl (ALL-INKL.COM - Neue Medien Münnich) | Allemagne (UE) | Hébergement du site d'information (aucune donnée client) | Décision d'adéquation (art. 16 al. 1 LPD) |
+
+DFX ne transfère des données personnelles que vers des pays disposant d'un niveau adéquat de protection des données (conformément à l'annexe 1 de l'ordonnance sur la protection des données), ou sous réserve de garanties appropriées telles que des clauses contractuelles types (art. 16 al. 2 let. d LPD). En outre, des données clients peuvent être transmises aux banques participantes en Suisse et à l'étranger dans le cadre de transactions bancaires (voir les Conditions générales).
 
 ### Révocation de votre consentement au traitement des données
 
@@ -117,7 +208,7 @@ Si vous avez limité le traitement de vos données à caractère personnel, ces 
 
 L'utilisation des données de contact publiées dans le cadre des mentions légales obligatoires pour l'envoi de publicité et de matériel d'information non expressément demandés est interdite. Les exploitants des pages se réservent expressément le droit d'engager des poursuites judiciaires en cas d'envoi non sollicité d'informations publicitaires, par exemple par le biais de spams.
 
-## 4. Collecte de données sur ce site web
+## 5. Collecte de données sur ce site web
 
 ### Cookies
 
@@ -139,11 +230,13 @@ Le traitement de ces données est basé sur l'article 6, paragraphe 1, point b) 
 
 Les données que vous nous avez envoyées par le biais de demandes de contact restent chez nous jusqu'à ce que vous nous demandiez de les effacer, que vous révoquiez votre consentement à leur stockage ou que la finalité du stockage des données devienne caduque (par ex. après le traitement de votre demande). Les dispositions légales contraignantes - en particulier les délais de conservation légaux - ne sont pas affectées.
 
-## 5. Outils d'analyse et publicité
+## 6. Outils d'analyse et publicité
 
-DFX n'utilise pas d'outils d'analyse tels que Google Analytics.
+DFX n'utilise pas d'outils d'analyse de site web pour le suivi du comportement des utilisateurs, tels que Google Analytics, Adobe Analytics ou des services comparables. Aucun pixel de suivi, cookie publicitaire ou technologie similaire d'analyse du comportement des utilisateurs n'est utilisé.
 
-## 6. lettre d'information
+Pour la surveillance opérationnelle côté serveur de l'infrastructure API, DFX utilise Microsoft Azure Application Insights (voir section 3 «Sous-traitants et prestataires tiers»). Cet outil est utilisé exclusivement pour la surveillance technique, la détection d'erreurs et l'optimisation des performances et ne collecte aucune donnée sur le comportement des utilisateurs sur le site web.
+
+## 7. lettre d'information
 
 ### Données de la newsletter
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -122,92 +122,20 @@ Les personnes concernées ont le droit de s'opposer au profilage et de demander 
 
 ## 4. Hébergement et infrastructure
 
-### Hébergement avec Cloudflare Pages
+DFX exploite l'API, la plateforme applicative et la base de données sur ses propres serveurs en Suisse.
 
-Nous hébergeons notre site Web avec Cloudflare Pages. Le fournisseur est Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (ci-après : Cloudflare).
+L'accès public à nos sites et services passe par Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) en tant que réseau de diffusion de contenu et reverse proxy. Lors de l'accès, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transmises à Cloudflare.
 
-Cloudflare a mis en œuvre des mesures techniques et organisationnelles appropriées pour assurer la protection des données personnelles. Des détails sur leur traitement des données personnelles peuvent être trouvés dans la [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/). Le traitement pour notre compte est régi par le [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
-
-### API et plateforme applicative avec Microsoft Azure
-
-L'infrastructure centrale de DFX — notamment l'API (api.dfx.swiss), la plateforme applicative (app.dfx.swiss) et la base de données — est exploitée sur Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Toutes les données personnelles traitées dans le cadre de l'utilisation de nos services financiers (y compris les données clients, les données de transactions, les données KYC et les documents d'identité) sont stockées et traitées sur l'infrastructure Azure.
-
-DFX utilise Azure App Services, Azure Storage, Azure CDN ainsi qu'une base de données Microsoft SQL Server. Le traitement des données s'effectue dans des centres de données Azure européens. Microsoft a mis en place des mesures techniques et organisationnelles appropriées pour garantir la protection des données personnelles. Le transfert de données vers les USA (le cas échéant) s'effectue sur la base du Swiss-US Data Privacy Framework et des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
-
-Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement) et les [conditions des services en ligne Microsoft](https://www.microsoft.com/licensing/terms).
+Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur des clauses contractuelles types (art. 16 al. 2 let. d LPD). Détails : [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/) et [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
-## 5. Sous-traitants et prestataires tiers
+## 5. Sous-traitants
 
-DFX fait appel à différents sous-traitants externes pour fournir ses services. Ceux-ci traitent les données personnelles exclusivement sur mandat et selon les instructions de DFX. DFX s'assure par des accords contractuels que tous les sous-traitants garantissent un niveau adéquat de protection des données.
+Lorsque cela est nécessaire à l'exécution du contrat ou au respect d'obligations légales, nous faisons appel aux sous-traitants suivants :
 
-### Vérification d'identité (KYC) avec Sumsub
-
-Pour la vérification d'identité légalement requise (Know Your Customer, KYC), DFX fait appel au prestataire Sumsub (Sum and Substance Ltd., Angleterre et Pays de Galles, Company No. 09688671) en tant que sous-traitant.
-
-#### Données traitées
-
-Dans le cadre de la vérification d'identité, les données personnelles suivantes sont transmises à Sumsub et traitées par celui-ci :
-
-* Données personnelles : prénom, nom, date de naissance, nationalité
-* Adresse : rue, numéro, code postal, ville, pays
-* Documents d'identité : passeport, carte d'identité ou autres documents officiels (copies/photos)
-* Données biométriques : images faciales (selfies), reconnaissance faciale et détection de vivacité pour la vérification d'identité
-* Enregistrements vidéo : dans le cadre de l'identification vidéo (si nécessaire)
-
-#### Données particulièrement sensibles (art. 5 let. c LPD)
-
-Les données biométriques traitées dans le cadre de la vérification d'identité (géométrie faciale, détection de vivacité) sont considérées comme des données personnelles particulièrement sensibles au sens de l'art. 5 let. c LPD. Le traitement de ces données s'effectue exclusivement sur la base de votre consentement exprès conformément à l'art. 6 al. 7 LPD, que vous donnez séparément avant le début du processus d'identification. Vous pouvez révoquer ce consentement à tout moment pour l'avenir ; toutefois, une révocation aura pour conséquence que la vérification d'identité ne pourra pas être achevée et que certains services de DFX ne pourront pas être utilisés.
-
-#### Transfert de données à l'étranger
-
-Sumsub a son siège en Angleterre et au Pays de Galles (Royaume-Uni). Le Royaume-Uni dispose d'une décision d'adéquation du Conseil fédéral suisse conformément à l'art. 16 al. 1 LPD, garantissant un niveau adéquat de protection des données sans nécessiter de garanties supplémentaires.
-
-#### Durée de conservation
-
-Les documents et données biométriques collectés dans le cadre de la vérification d'identité sont conservés par DFX pendant la durée légale de conservation de 10 ans après la fin de la relation d'affaires (art. 7 LBA). Les données biométriques brutes chez Sumsub sont supprimées conformément aux accords contractuels après la conclusion de la vérification.
-
-Pour plus d'informations sur la protection des données chez Sumsub, veuillez consulter la [politique de confidentialité de Sumsub](https://sumsub.com/privacy-notice-service/).
-
-### Prévention de la fraude avec Sift
-
-DFX fait appel au prestataire Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) en tant que sous-traitant pour la prévention de la fraude et la lutte contre le blanchiment d'argent.
-
-#### Données traitées
-
-Les données suivantes sont transmises à Sift dans le cadre de la prévention de la fraude :
-
-* Informations de compte : identifiant utilisateur, date de création, niveau KYC
-* Données de transactions : montant, devise, moyen de paiement (4 derniers chiffres de la carte de crédit ou 6 premiers et 4 derniers chiffres de l'IBAN), adresse blockchain
-* Données techniques : adresse IP, informations sur l'appareil, type de navigateur
-* Données de connexion : horodatage et type de connexion
-
-#### Transfert de données à l'étranger
-
-Sift a son siège aux USA. Le transfert de données s'effectue sur la base du Swiss-US Data Privacy Framework, dans la mesure où Sift est certifié sous ce cadre, ou sur la base de clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
-
-Pour plus d'informations, veuillez consulter la [politique de confidentialité de Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
-
-### Contrôle des sanctions avec Dilisense
-
-DFX fait appel au prestataire Dilisense pour la vérification des clients par rapport aux listes de sanctions, aux listes PEP (personnes politiquement exposées) et aux casiers judiciaires. Dans le cadre de ce contrôle, le nom, la date de naissance et la nationalité du client sont transmis.
-
-### Surveillance côté serveur avec Azure Application Insights
-
-DFX utilise Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) à des fins de surveillance opérationnelle, de détection d'erreurs et d'optimisation des performances de l'infrastructure API. Application Insights n'est pas un outil d'analyse de site web pour le suivi du comportement des utilisateurs, mais un outil de surveillance côté serveur.
-
-#### Données traitées
-
-* Données de requêtes techniques : chemins URL, codes de statut HTTP, temps de réponse
-* Journaux d'erreurs et d'exceptions : traces de pile, messages d'erreur
-* Dépendances : appels aux bases de données et services externes
-* Adresses IP : dans le cadre du traitement des requêtes
-
-Aucun contenu personnel (tel que noms, adresses ou données financières) n'est transmis à Application Insights.
-
-#### Transfert de données à l'étranger
-
-Microsoft peut traiter des données dans des centres de données en dehors de la Suisse (UE/USA). Le transfert de données s'effectue sur la base des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD et du Swiss-US Data Privacy Framework. Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement).
+* Sumsub (Sum and Substance Ltd., Royaume-Uni) — vérification d'identité légalement requise, y compris les documents d'identité et les données biométriques. Le Royaume-Uni bénéficie d'une décision d'adéquation (art. 16 al. 1 LPD). Nous ne traitons des données biométriques qu'avec votre consentement exprès (art. 6 al. 7 LPD).
+* Sift Science, Inc. (USA) — prévention de la fraude. Le transfert repose sur le Swiss-U.S. Data Privacy Framework ou sur des clauses contractuelles types (art. 16 al. 2 let. d LPD).
+* Dilisense (UE) — contrôle des listes de sanctions et PEP. Décision d'adéquation (art. 16 al. 1 LPD).
 
 
 ## 6. Notes générales et informations obligatoires
@@ -253,21 +181,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Pour l'hébergement, nous utilisons Cloudflare Pages, un service fourni par Cloudflare, Inc., basée aux États-Unis. Lorsque vous accédez à notre site Web, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transférées aux États-Unis et y sont traitées, car Cloudflare termine la connexion en tant que reverse proxy / réseau de diffusion de contenu (CDN).
-
-Base juridique du transfert de données vers les États-Unis : Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur les clauses contractuelles types de la Commission européenne. Malgré ces garanties, un accès des autorités américaines (par exemple en vertu du CLOUD Act) ne peut être entièrement exclu.
-
-Dans le cadre de nos activités commerciales, des données personnelles sont transmises aux destinataires dans les pays suivants :
-
-| Destinataire | Pays | Finalité | Base juridique |
-|-------------|------|----------|----------------|
-| Microsoft Corporation (Azure) | UE / USA | Hébergement de l'API, base de données, plateforme applicative, surveillance | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
-| Sumsub (Sum and Substance Ltd.) | Royaume-Uni | Vérification d'identité (KYC) | Décision d'adéquation (art. 16 al. 1 LPD) |
-| Sift Science, Inc. | USA | Prévention de la fraude | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
-| Dilisense | UE | Contrôle des sanctions et PEP | Décision d'adéquation (art. 16 al. 1 LPD) |
-| Cloudflare, Inc. | USA | Hébergement du site web et de la documentation (Cloudflare Pages) | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
-
-DFX ne transfère des données personnelles que vers des pays disposant d'un niveau adéquat de protection des données (conformément à l'annexe 1 de l'ordonnance sur la protection des données), ou sous réserve de garanties appropriées telles que des clauses contractuelles types (art. 16 al. 2 let. d LPD). En outre, des données clients peuvent être transmises aux banques participantes en Suisse et à l'étranger dans le cadre de transactions bancaires (voir les Conditions générales).
+Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises uniquement à Cloudflare (USA, accès aux services) et aux sous-traitants cités ci-dessus. En outre, des données clients peuvent être transmises aux banques participantes en Suisse et à l'étranger dans le cadre de transactions bancaires (voir les Conditions générales).
 
 ### Cryptage SSL ou TLS
 
@@ -337,8 +251,6 @@ Les données que vous nous envoyez via les demandes de contact resteront chez no
 ## 9. Outils d'analyse et publicité
 
 DFX n'utilise pas d'outils d'analyse de sites Web tels que Google Analytics, Adobe Analytics ou autres. Aucun pixel de suivi, cookie publicitaire ou technologie similaire d'analyse du comportement des utilisateurs n'est utilisé.
-
-Pour la surveillance opérationnelle côté serveur de l'infrastructure API, DFX utilise Microsoft Azure Application Insights (voir section 5 «Sous-traitants et prestataires tiers»). Cet outil est utilisé exclusivement pour la surveillance technique, la détection d'erreurs et l'optimisation des performances et ne collecte aucune donnée sur le comportement des utilisateurs sur le site web.
 
 
 ## 10. Newsletter et réseaux sociaux

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -124,7 +124,7 @@ Les personnes concernées ont le droit de s'opposer au profilage et de demander 
 
 DFX héberge les pages d'information statiques qui ne collectent aucune donnée client (par exemple dfx.swiss) chez Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Ces pages n'ont ni compte client, ni transactions, ni vérification d'identité.
 
-Tout ce qui traite des données clients — l'API, la plateforme applicative et la base de données — est exploité par DFX sur ses propres serveurs en Suisse. L'accès public à ces services passe par Cloudflare en tant que réseau de diffusion de contenu et reverse proxy.
+DFX exploite l'API, la plateforme applicative et la base de données sur ses propres serveurs en Suisse. L'accès public à ces services passe par Cloudflare en tant que réseau de diffusion de contenu et reverse proxy.
 
 Lors de l'accès, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transmises à Cloudflare. Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur des clauses contractuelles types (art. 16 al. 2 let. d LPD). Détails : [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/) et [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des pages statiques sans données clients et accès aux services), à Sumsub (Royaume-Uni) et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
+Les données clients de la plateforme de négociation sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des pages statiques sans données clients et accès aux services), à Sumsub (Royaume-Uni) et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales). Les transferts par les réseaux sociaux cités ci-dessous sont décrits à la section 10.
 
 ### Cryptage SSL ou TLS
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -134,7 +134,7 @@ Lors de l'accès, des données techniquement nécessaires (notamment votre adres
 Lorsque cela est nécessaire à l'exécution du contrat ou au respect d'obligations légales, nous faisons appel aux sous-traitants suivants :
 
 * Sumsub (Sum and Substance Ltd., Royaume-Uni) — vérification d'identité légalement requise, y compris les documents d'identité et les données biométriques. Le Royaume-Uni bénéficie d'une décision d'adéquation (art. 16 al. 1 LPD). Nous ne traitons des données biométriques qu'avec votre consentement exprès (art. 6 al. 7 LPD).
-* Dilisense (UE) — contrôle des listes de sanctions et PEP. Décision d'adéquation (art. 16 al. 1 LPD).
+* Dilisense (Suisse) — contrôle des listes de sanctions et PEP.
 
 
 ## 6. Notes générales et informations obligatoires

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -180,7 +180,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des pages statiques sans données clients et accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
+Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des pages statiques sans données clients et accès aux services), à Sumsub (Royaume-Uni) et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
 
 ### Cryptage SSL ou TLS
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -249,7 +249,7 @@ Les données que vous nous envoyez via les demandes de contact resteront chez no
 
 ## 9. Outils d'analyse et publicité
 
-DFX n'utilise pas d'outils d'analyse de sites Web tels que Google Analytics, Adobe Analytics ou autres. Aucun pixel de suivi, cookie publicitaire ou technologie similaire d'analyse du comportement des utilisateurs n'est utilisé.
+DFX n'utilise pas d'outils d'analyse de sites Web pour le suivi du comportement des utilisateurs, tels que Google Analytics, Adobe Analytics ou des services comparables. Aucun pixel de suivi, cookie publicitaire ou technologie similaire d'analyse du comportement des utilisateurs n'est utilisé.
 
 
 ## 10. Newsletter et réseaux sociaux

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -306,7 +306,7 @@ En cas de violation de la protection des données, DFX suit une procédure struc
 
 #### Obligations de notification
 
-En cas de violation de la protection des données présentant un risque pour les droits et libertés des personnes concernées, DFX est légalement tenu d'en informer certaines parties. Ces notifications visent à garantir que tant les autorités compétentes que les personnes concernées soient informées en temps utile de la violation et des mesures prises. Les notifications sont effectuées conformément aux exigences légales et comprennent les étapes suivantes :
+En cas de violation de la protection des données susceptible d'entraîner un risque élevé pour la personnalité ou les droits fondamentaux des personnes concernées, DFX est légalement tenu d'en informer certaines parties. Ces notifications visent à garantir que tant les autorités compétentes que les personnes concernées soient informées en temps utile de la violation et des mesures prises. Les notifications sont effectuées conformément aux exigences légales et comprennent les étapes suivantes :
 
 * Notification de l'autorité de surveillance compétente (PFPDT) dès que possible après la prise de connaissance de la violation (art. 24 al. 1 LPD).
 * Notification des personnes concernées, si cela est nécessaire à leur protection ou si le PFPDT l'exige (art. 24 al. 4 LPD), sans délai et dans un langage clair et compréhensible.
@@ -336,7 +336,7 @@ Les données que vous nous envoyez via les demandes de contact resteront chez no
 
 ## 9. Outils d'analyse et publicité
 
-DFX n'utilise pas d'outils d'analyse de sites Web tels que Google Analytics, Adobe Analytics ou autres.
+DFX n'utilise pas d'outils d'analyse de sites Web tels que Google Analytics, Adobe Analytics ou autres. Aucun pixel de suivi, cookie publicitaire ou technologie similaire d'analyse du comportement des utilisateurs n'est utilisé.
 
 Pour la surveillance opérationnelle côté serveur de l'infrastructure API, DFX utilise Microsoft Azure Application Insights (voir section 5 «Sous-traitants et prestataires tiers»). Cet outil est utilisé exclusivement pour la surveillance technique, la détection d'erreurs et l'optimisation des performances et ne collecte aucune donnée sur le comportement des utilisateurs sur le site web.
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -180,7 +180,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises uniquement à Cloudflare (USA, accès aux services) et aux sous-traitants cités ci-dessus. En outre, des données clients peuvent être transmises aux banques participantes en Suisse et à l'étranger dans le cadre de transactions bancaires (voir les Conditions générales).
+Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
 
 ### Cryptage SSL ou TLS
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -122,11 +122,11 @@ Les personnes concernées ont le droit de s'opposer au profilage et de demander 
 
 ## 4. Hébergement et infrastructure
 
-DFX exploite l'API, la plateforme applicative et la base de données sur ses propres serveurs en Suisse.
+DFX héberge les sites web statiques sans données clients (par exemple dfx.swiss) chez Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
 
-L'accès public à nos sites et services passe par Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) en tant que réseau de diffusion de contenu et reverse proxy. Lors de l'accès, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transmises à Cloudflare.
+DFX exploite l'API, la plateforme applicative et la base de données sur ses propres serveurs en Suisse. L'accès public à ces services passe par Cloudflare en tant que réseau de diffusion de contenu et reverse proxy.
 
-Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur des clauses contractuelles types (art. 16 al. 2 let. d LPD). Détails : [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/) et [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
+Lors de l'accès, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transmises à Cloudflare. Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur des clauses contractuelles types (art. 16 al. 2 let. d LPD). Détails : [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/) et [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Sous-traitants
@@ -180,7 +180,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
+Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des sites statiques et accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
 
 ### Cryptage SSL ou TLS
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -134,7 +134,6 @@ Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](h
 Lorsque cela est nécessaire à l'exécution du contrat ou au respect d'obligations légales, nous faisons appel aux sous-traitants suivants :
 
 * Sumsub (Sum and Substance Ltd., Royaume-Uni) — vérification d'identité légalement requise, y compris les documents d'identité et les données biométriques. Le Royaume-Uni bénéficie d'une décision d'adéquation (art. 16 al. 1 LPD). Nous ne traitons des données biométriques qu'avec votre consentement exprès (art. 6 al. 7 LPD).
-* Sift Science, Inc. (USA) — prévention de la fraude. Le transfert repose sur le Swiss-U.S. Data Privacy Framework ou sur des clauses contractuelles types (art. 16 al. 2 let. d LPD).
 * Dilisense (UE) — contrôle des listes de sanctions et PEP. Décision d'adéquation (art. 16 al. 1 LPD).
 
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -120,7 +120,7 @@ DFX ne met pas en œuvre de processus décisionnels purement automatisés, jurid
 Les personnes concernées ont le droit de s'opposer au profilage et de demander des informations sur la logique sous-jacente et les effets du profilage sur elles.
 
 
-## 4. Hébergement
+## 4. Hébergement et infrastructure
 
 ### Hébergement avec Cloudflare Pages
 
@@ -128,8 +128,89 @@ Nous hébergeons notre site Web avec Cloudflare Pages. Le fournisseur est Cloudf
 
 Cloudflare a mis en œuvre des mesures techniques et organisationnelles appropriées pour assurer la protection des données personnelles. Des détails sur leur traitement des données personnelles peuvent être trouvés dans la [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/). Le traitement pour notre compte est régi par le [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
+### API et plateforme applicative avec Microsoft Azure
 
-## 5. Notes générales et informations obligatoires
+L'infrastructure centrale de DFX — notamment l'API (api.dfx.swiss), la plateforme applicative (app.dfx.swiss) et la base de données — est exploitée sur Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Toutes les données personnelles traitées dans le cadre de l'utilisation de nos services financiers (y compris les données clients, les données de transactions, les données KYC et les documents d'identité) sont stockées et traitées sur l'infrastructure Azure.
+
+DFX utilise Azure App Services, Azure Storage, Azure CDN ainsi qu'une base de données Microsoft SQL Server. Le traitement des données s'effectue dans des centres de données Azure européens. Microsoft a mis en place des mesures techniques et organisationnelles appropriées pour garantir la protection des données personnelles. Le transfert de données vers les USA (le cas échéant) s'effectue sur la base du Swiss-US Data Privacy Framework et des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
+
+Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement) et les [conditions des services en ligne Microsoft](https://www.microsoft.com/licensing/terms).
+
+
+## 5. Sous-traitants et prestataires tiers
+
+DFX fait appel à différents sous-traitants externes pour fournir ses services. Ceux-ci traitent les données personnelles exclusivement sur mandat et selon les instructions de DFX. DFX s'assure par des accords contractuels que tous les sous-traitants garantissent un niveau adéquat de protection des données.
+
+### Vérification d'identité (KYC) avec Sumsub
+
+Pour la vérification d'identité légalement requise (Know Your Customer, KYC), DFX fait appel au prestataire Sumsub (Sum and Substance Ltd., Angleterre et Pays de Galles, Company No. 09688671) en tant que sous-traitant.
+
+#### Données traitées
+
+Dans le cadre de la vérification d'identité, les données personnelles suivantes sont transmises à Sumsub et traitées par celui-ci :
+
+* Données personnelles : prénom, nom, date de naissance, nationalité
+* Adresse : rue, numéro, code postal, ville, pays
+* Documents d'identité : passeport, carte d'identité ou autres documents officiels (copies/photos)
+* Données biométriques : images faciales (selfies), reconnaissance faciale et détection de vivacité pour la vérification d'identité
+* Enregistrements vidéo : dans le cadre de l'identification vidéo (si nécessaire)
+
+#### Données particulièrement sensibles (art. 5 let. c LPD)
+
+Les données biométriques traitées dans le cadre de la vérification d'identité (géométrie faciale, détection de vivacité) sont considérées comme des données personnelles particulièrement sensibles au sens de l'art. 5 let. c LPD. Le traitement de ces données s'effectue exclusivement sur la base de votre consentement exprès conformément à l'art. 6 al. 7 LPD, que vous donnez séparément avant le début du processus d'identification. Vous pouvez révoquer ce consentement à tout moment pour l'avenir ; toutefois, une révocation aura pour conséquence que la vérification d'identité ne pourra pas être achevée et que certains services de DFX ne pourront pas être utilisés.
+
+#### Transfert de données à l'étranger
+
+Sumsub a son siège en Angleterre et au Pays de Galles (Royaume-Uni). Le Royaume-Uni dispose d'une décision d'adéquation du Conseil fédéral suisse conformément à l'art. 16 al. 1 LPD, garantissant un niveau adéquat de protection des données sans nécessiter de garanties supplémentaires.
+
+#### Durée de conservation
+
+Les documents et données biométriques collectés dans le cadre de la vérification d'identité sont conservés par DFX pendant la durée légale de conservation de 10 ans après la fin de la relation d'affaires (art. 7 LBA). Les données biométriques brutes chez Sumsub sont supprimées conformément aux accords contractuels après la conclusion de la vérification.
+
+Pour plus d'informations sur la protection des données chez Sumsub, veuillez consulter la [politique de confidentialité de Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Prévention de la fraude avec Sift
+
+DFX fait appel au prestataire Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) en tant que sous-traitant pour la prévention de la fraude et la lutte contre le blanchiment d'argent.
+
+#### Données traitées
+
+Les données suivantes sont transmises à Sift dans le cadre de la prévention de la fraude :
+
+* Informations de compte : identifiant utilisateur, date de création, niveau KYC
+* Données de transactions : montant, devise, moyen de paiement (4 derniers chiffres de la carte de crédit ou 6 premiers et 4 derniers chiffres de l'IBAN), adresse blockchain
+* Données techniques : adresse IP, informations sur l'appareil, type de navigateur
+* Données de connexion : horodatage et type de connexion
+
+#### Transfert de données à l'étranger
+
+Sift a son siège aux USA. Le transfert de données s'effectue sur la base du Swiss-US Data Privacy Framework, dans la mesure où Sift est certifié sous ce cadre, ou sur la base de clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD.
+
+Pour plus d'informations, veuillez consulter la [politique de confidentialité de Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Contrôle des sanctions avec Dilisense
+
+DFX fait appel au prestataire Dilisense pour la vérification des clients par rapport aux listes de sanctions, aux listes PEP (personnes politiquement exposées) et aux casiers judiciaires. Dans le cadre de ce contrôle, le nom, la date de naissance et la nationalité du client sont transmis.
+
+### Surveillance côté serveur avec Azure Application Insights
+
+DFX utilise Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) à des fins de surveillance opérationnelle, de détection d'erreurs et d'optimisation des performances de l'infrastructure API. Application Insights n'est pas un outil d'analyse de site web pour le suivi du comportement des utilisateurs, mais un outil de surveillance côté serveur.
+
+#### Données traitées
+
+* Données de requêtes techniques : chemins URL, codes de statut HTTP, temps de réponse
+* Journaux d'erreurs et d'exceptions : traces de pile, messages d'erreur
+* Dépendances : appels aux bases de données et services externes
+* Adresses IP : dans le cadre du traitement des requêtes
+
+Aucun contenu personnel (tel que noms, adresses ou données financières) n'est transmis à Application Insights.
+
+#### Transfert de données à l'étranger
+
+Microsoft peut traiter des données dans des centres de données en dehors de la Suisse (UE/USA). Le transfert de données s'effectue sur la base des clauses contractuelles types conformément à l'art. 16 al. 2 let. d LPD et du Swiss-US Data Privacy Framework. Pour plus d'informations, veuillez consulter la [politique de confidentialité de Microsoft](https://privacy.microsoft.com/fr-fr/privacystatement).
+
+
+## 6. Notes générales et informations obligatoires
 
 ### Période de stockage
 
@@ -176,6 +257,18 @@ Pour l'hébergement, nous utilisons Cloudflare Pages, un service fourni par Clou
 
 Base juridique du transfert de données vers les États-Unis : Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur les clauses contractuelles types de la Commission européenne. Malgré ces garanties, un accès des autorités américaines (par exemple en vertu du CLOUD Act) ne peut être entièrement exclu.
 
+Dans le cadre de nos activités commerciales, des données personnelles sont transmises aux destinataires dans les pays suivants :
+
+| Destinataire | Pays | Finalité | Base juridique |
+|-------------|------|----------|----------------|
+| Microsoft Corporation (Azure) | UE / USA | Hébergement de l'API, base de données, plateforme applicative, surveillance | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
+| Sumsub (Sum and Substance Ltd.) | Royaume-Uni | Vérification d'identité (KYC) | Décision d'adéquation (art. 16 al. 1 LPD) |
+| Sift Science, Inc. | USA | Prévention de la fraude | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
+| Dilisense | UE | Contrôle des sanctions et PEP | Décision d'adéquation (art. 16 al. 1 LPD) |
+| Cloudflare, Inc. | USA | Hébergement du site web et de la documentation (Cloudflare Pages) | Swiss-US DPF / Clauses contractuelles types (art. 16 al. 2 LPD) |
+
+DFX ne transfère des données personnelles que vers des pays disposant d'un niveau adéquat de protection des données (conformément à l'annexe 1 de l'ordonnance sur la protection des données), ou sous réserve de garanties appropriées telles que des clauses contractuelles types (art. 16 al. 2 let. d LPD). En outre, des données clients peuvent être transmises aux banques participantes en Suisse et à l'étranger dans le cadre de transactions bancaires (voir les Conditions générales).
+
 ### Cryptage SSL ou TLS
 
 Pour des raisons de sécurité et pour protéger la transmission de contenus confidentiels, tels que les demandes que vous nous envoyez en tant qu'opérateur du site, ce site utilise le cryptage SSL ou TLS. Vous pouvez reconnaître une connexion cryptée au fait que la ligne d'adresse du navigateur passe de « http:// » à « https:// » et au symbole de cadenas dans la ligne de votre navigateur.
@@ -199,7 +292,7 @@ Les droits ci-dessus peuvent être refusés ou restreints si les intérêts, dro
 Nous nous opposons par la présente à l'utilisation des données de contact publiées dans le cadre de l'obligation d'impression pour l'envoi de matériel publicitaire et d'information non sollicité. Les exploitants des pages se réservent expressément le droit d'engager des poursuites judiciaires en cas d'envoi non sollicité d'informations publicitaires, telles que des spams.
 
 
-## 6. Violations de la protection des données
+## 7. Violations de la protection des données
 
 DFX prend très au sérieux les violations de la protection des données et a mis en œuvre des processus pour gérer de tels incidents de manière efficace et conformément aux exigences légales. Une violation de la protection des données se produit lorsque des données personnelles sont divulguées, modifiées, supprimées ou rendues accessibles de manière involontaire ou illégale sans autorisation.
 
@@ -215,8 +308,9 @@ En cas de violation de la protection des données, DFX suit une procédure struc
 
 En cas de violation de la protection des données présentant un risque pour les droits et libertés des personnes concernées, DFX est légalement tenu d'en informer certaines parties. Ces notifications visent à garantir que tant les autorités compétentes que les personnes concernées soient informées en temps utile de la violation et des mesures prises. Les notifications sont effectuées conformément aux exigences légales et comprennent les étapes suivantes :
 
-* Notification à l'autorité de contrôle dans les 72 heures suivant la prise de connaissance de l'infraction.
-* Notification des personnes concernées sans délai et dans un langage clair et compréhensible.
+* Notification de l'autorité de surveillance compétente (PFPDT) dès que possible après la prise de connaissance de la violation (art. 24 al. 1 LPD).
+* Notification des personnes concernées, si cela est nécessaire à leur protection ou si le PFPDT l'exige (art. 24 al. 4 LPD), sans délai et dans un langage clair et compréhensible.
+* Les sous-traitants de DFX (tels que Sumsub, Sift et d'autres) sont contractuellement tenus d'informer DFX immédiatement des violations de la protection des données (art. 24 al. 3 LPD).
    
 ### Mesures de protection
 
@@ -227,7 +321,7 @@ Pour prévenir les violations de la protection des données, nous utilisons des 
 Si vous constatez une éventuelle violation de la protection des données, veuillez contacter notre [Support](https://services.dfx.swiss/support).
 
 
-## 7. Collecte de données sur ce site Web
+## 8. Collecte de données sur ce site Web
 
 ### Cookies
 
@@ -240,12 +334,14 @@ Si vous nous contactez par e-mail, téléphone ou fax, votre demande, y compris 
 Les données que vous nous envoyez via les demandes de contact resteront chez nous jusqu'à ce que vous nous demandiez de les supprimer, que vous révoquiez votre consentement au stockage ou que la finalité du stockage des données ne s'applique plus (par exemple, après le traitement de votre demande). Les dispositions légales obligatoires - en particulier les délais de conservation légaux - restent inchangées.
 
 
-## 8. Outils d'analyse et publicité
+## 9. Outils d'analyse et publicité
 
 DFX n'utilise pas d'outils d'analyse de sites Web tels que Google Analytics, Adobe Analytics ou autres.
 
+Pour la surveillance opérationnelle côté serveur de l'infrastructure API, DFX utilise Microsoft Azure Application Insights (voir section 5 «Sous-traitants et prestataires tiers»). Cet outil est utilisé exclusivement pour la surveillance technique, la détection d'erreurs et l'optimisation des performances et ne collecte aucune donnée sur le comportement des utilisateurs sur le site web.
 
-## 9. Newsletter et réseaux sociaux
+
+## 10. Newsletter et réseaux sociaux
 
 ### Données de la newsletter
 
@@ -314,7 +410,7 @@ Le transfert de données vers les États-Unis est basé sur les clauses contract
 Des détails sur la manière dont ils traitent vos données personnelles peuvent être trouvés dans la [Politique de confidentialité de LinkedIn](https://www.linkedin.com/legal/privacy-policy).
 
 
-## 10. Protection des données pour les candidatures et pendant le processus de candidature
+## 11. Protection des données pour les candidatures et pendant le processus de candidature
 
 Le responsable du traitement collecte et traite les données personnelles des candidats dans le but de mener à bien la procédure de candidature. Ce traitement peut également avoir lieu par voie électronique, en particulier si les candidats envoient également les documents de candidature pertinents par courrier électronique (par exemple au format PDF ou dans d'autres types de fichiers).
 
@@ -327,20 +423,20 @@ Si le responsable du traitement conclut un contrat de travail avec un candidat, 
 Si aucun contrat de travail n'est conclu, les documents de candidature seront automatiquement supprimés 12 mois après la notification de la décision de rejet sans autre notification, à condition qu'aucun autre intérêt légitime du centre de traitement des données n'empêche la suppression. Les intérêts légitimes peuvent être, par exemple, l’obligation de fournir des preuves dans le cadre d’une procédure en vertu de la loi sur l’égalité de traitement (GlG).
 
 
-## 11. Loi applicable et juridiction
+## 12. Loi applicable et juridiction
 
 Le site Internet DFX ayant son siège social en Suisse est régi exclusivement par le droit suisse (protection des données), à moins qu'une autre loi impérative ne soit applicable à la personne physique concernée.
 
 Le tribunal du siège social de DFX (Suisse) est seul compétent pour tout litige entre vous en tant que visiteur et utilisateur du site Internet DFX résultant de l'exploitation ou de la visite des sites Internet, à moins qu'un autre for obligatoire ne soit applicable à la personne physique concernée.
 
 
-## 12. Modifications de la politique de confidentialité
+## 13. Modifications de la politique de confidentialité
 
 DFX revoit régulièrement cette politique de confidentialité pour s'assurer qu'elle est toujours à jour et se réserve le droit de la modifier si nécessaire. Il est recommandé de consulter régulièrement cette page pour connaître d'éventuelles modifications, car aucune notification individuelle de modification ne sera effectuée.
 En cas de divergences avec la version anglaise, la version allemande de cette politique de confidentialité prévaudra.
 
 
-## 13. Informations légales et clause de non-responsabilité
+## 14. Informations légales et clause de non-responsabilité
 
 DFX décline toute responsabilité quant à l'exactitude et à l'exhaustivité du contenu des informations.
 
@@ -349,19 +445,19 @@ Les réclamations en responsabilité liées à des dommages matériels ou immat�
 Toutes les offres publiées par DFX sous forme numérique ou électronique sont susceptibles d'être modifiées. DFX se réserve expressément le droit de modifier, compléter ou supprimer des parties des pages ou l'ensemble de l'offre sans préavis ou de cesser la publication temporairement ou définitivement.
 
 
-## 14. Responsabilité des liens
+## 15. Responsabilité des liens
 
 Les références et liens vers des sites Web tiers ne relèvent pas de la responsabilité de DFX. Toute responsabilité concernant les sites Web de tiers, c'est-à-dire extérieurs aux sociétés appartenant à DFX, est rejetée. L'accès et l'utilisation de ces sites Web se font aux propres risques de l'utilisateur.
 
 Toutes les offres publiées par DFX sous forme numérique ou électronique sont susceptibles d'être modifiées. DFX se réserve expressément le droit de modifier, compléter ou supprimer des parties des pages ou l'ensemble de l'offre sans préavis ou de cesser la publication temporairement ou définitivement.
 
 
-## 15. Droits d'auteur et propriété intellectuelle
+## 16. Droits d'auteur et propriété intellectuelle
 
 Le droit d'auteur et tous les autres droits sur le contenu, les images, les photos ou autres fichiers du site Web DFX appartiennent exclusivement à DFX et à ses sociétés affiliées, à leurs fournisseurs ou aux titulaires de droits spécifiquement nommés.
 
 
-## 16. Consentement à la politique de confidentialité
+## 17. Consentement à la politique de confidentialité
 
 Le client accepte dans son intégralité le contenu de la politique de confidentialité dans sa version actuelle. En cas de contradictions, la politique de confidentialité prévaut sur les Conditions Générales de DFX.
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -122,9 +122,9 @@ Les personnes concernées ont le droit de s'opposer au profilage et de demander 
 
 ## 4. Hébergement et infrastructure
 
-DFX héberge les sites web statiques sans données clients (par exemple dfx.swiss) chez Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
+DFX héberge les pages d'information statiques qui ne collectent aucune donnée client (par exemple dfx.swiss) chez Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Ces pages n'ont ni compte client, ni transactions, ni vérification d'identité.
 
-DFX exploite l'API, la plateforme applicative et la base de données sur ses propres serveurs en Suisse. L'accès public à ces services passe par Cloudflare en tant que réseau de diffusion de contenu et reverse proxy.
+Tout ce qui traite des données clients — l'API, la plateforme applicative et la base de données — est exploité par DFX sur ses propres serveurs en Suisse. L'accès public à ces services passe par Cloudflare en tant que réseau de diffusion de contenu et reverse proxy.
 
 Lors de l'accès, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transmises à Cloudflare. Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur des clauses contractuelles types (art. 16 al. 2 let. d LPD). Détails : [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/) et [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des sites statiques et accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
+Les données personnelles sont traitées en Suisse. En dehors de la Suisse, elles sont transmises à Cloudflare (USA, hébergement des pages statiques sans données clients et accès aux services), aux sous-traitants cités ci-dessus et, dans le cadre de transactions bancaires, aux banques participantes (voir les Conditions générales).
 
 ### Cryptage SSL ou TLS
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -224,7 +224,7 @@ En cas de violation de la protection des données susceptible d'entraîner un ri
 
 * Notification de l'autorité de surveillance compétente (PFPDT) dès que possible après la prise de connaissance de la violation (art. 24 al. 1 LPD).
 * Notification des personnes concernées, si cela est nécessaire à leur protection ou si le PFPDT l'exige (art. 24 al. 4 LPD), sans délai et dans un langage clair et compréhensible.
-* Les sous-traitants de DFX (tels que Sumsub, Sift et d'autres) sont contractuellement tenus d'informer DFX immédiatement des violations de la protection des données (art. 24 al. 3 LPD).
+* Les sous-traitants cités ci-dessus sont contractuellement tenus d'informer DFX immédiatement des violations de la protection des données (art. 24 al. 3 LPD).
    
 ### Mesures de protection
 

--- a/src/fr/tnc.md
+++ b/src/fr/tnc.md
@@ -78,9 +78,9 @@ Pour les transactions de blockchain de DFX vers des wallets non self-hosted, ces
 
 Avant de pouvoir utiliser les services financiers de DFX, le client doit s'enregistrer via l'application DFX ou sur la page de paiement. L'inscription est gratuite et donne lieu à la création d'un profil d'utilisateur après acceptation des conditions générales actuelles. De plus, un portefeuille non-custody est créé. DFX n'y a pas accès, seul le client y a accès. Lorsqu'un client s'enregistre, les informations et documents que le client doit transmettre à DFX et le montant maximal pour lequel le client peut acheter ou vendre des cryptomonnaies dépendent de son niveau d'identification :
 
-L'enregistrement se fait en principe via l'adresse de la blockchain en indiquant l'e-mail ou le numéro de téléphone du client. Cet enregistrement est considéré comme standard - light KYC (Know-your-Customer) - et permet au client d'acheter/vendre des cryptomonnaies jusqu'à la limite journalière fixée, visible sur la page de paiement personnelle du client. Les transferts de crypto-monnaies vers une adresse publique non vérifiée ne sont pas acceptés.
+L'enregistrement se fait en principe via l'adresse de la blockchain en indiquant l'e-mail ou le numéro de téléphone du client. Cet enregistrement est considéré comme standard - light KYC (Know-your-Customer) - et permet au client d'acheter/vendre des cryptomonnaies jusqu'à la limite mensuelle fixée (période glissante de 30 jours), visible sur la page de paiement personnelle du client. Les transferts de crypto-monnaies vers une adresse publique non vérifiée ne sont pas acceptés.
 
-Pour l'achat/la vente de crypto-monnaies au-delà de cette limite journalière, il est nécessaire de procéder à un enregistrement plus détaillé, qui est considéré comme un processus KYC (Know-your-Customer) étendu et complet. Dans le cadre de ce processus, les informations suivantes doivent notamment être communiquées à DFX :
+Pour l'achat/la vente de crypto-monnaies au-delà de cette limite mensuelle, il est nécessaire de procéder à un enregistrement plus détaillé, qui est considéré comme un processus KYC (Know-your-Customer) étendu et complet. Dans le cadre de ce processus, les informations suivantes doivent notamment être communiquées à DFX :
 
 
 - adresse, la preuve de celle-ci étant apportée par l'envoi d'une lettre à l'adresse indiquée.
@@ -164,7 +164,7 @@ Les routes de vente peuvent être annulées tant que la crypto-monnaie à conver
 
 Les frais de transaction des [crypto, respectivement] monnaies étrangères transmises au client sont compris dans le prix de base. Les prix s'entendent dans la crypto-monnaie autorisée pour la transaction et incluent la taxe sur la valeur ajoutée (ci-après : TVA) suisse, le cas échéant. Une fois que le transfert [de la crypto-monnaie souhaitée ou] de la monnaie étrangère souhaitée a été effectué sur le compte [/portefeuille] du client, la vente est considérée comme conclue. Le client reçoit une confirmation de la conclusion de la transaction par e-mail, accompagnée d'un aperçu de la transaction.
 
-DFX attire l'attention sur le fait qu'il existe un volume de vente maximal par jour et par client, qui peut être consulté par le client sur la page de paiement. Le client a la possibilité de demander un volume de vente plus élevé. Cette demande est évaluée et discutée individuellement par DFX.  
+DFX attire l'attention sur le fait qu'il existe un volume de vente maximal par mois (période glissante de 30 jours) et par client, qui peut être consulté par le client sur la page de paiement. Le client a la possibilité de demander un volume de vente plus élevé. Cette demande est évaluée et discutée individuellement par DFX.  
 
 Les contre-passations de ventes aux clients de DFX AG sont effectuées exclusivement dans la crypto-monnaie qui a été transférée à DFX pour la vente. Le montant de la rétrofacturation correspond exactement au montant qui a été transféré à DFX pour la vente.
 

--- a/src/fr/tnc.md
+++ b/src/fr/tnc.md
@@ -142,9 +142,9 @@ Pour les transactions blockchain de DFX vers des portefeuilles non auto-héberg�
 ## Inscription des utilisateurs
 Avant de pouvoir utiliser les services financiers de DFX, le client doit s'inscrire. L'inscription est gratuite pour les particuliers et donne lieu, après acceptation des présentes conditions générales, à la création d'un profil d'utilisateur. Lorsqu'un client s'inscrit, les informations et documents que le client doit soumettre à DFX et le montant maximum pour lequel le client peut acheter ou vendre des crypto-monnaies dépendent de son niveau d'identification :
 
-L'inscription s'effectue généralement via l'adresse blockchain, en fournissant l'email ou le numéro de téléphone du client. Cet enregistrement est considéré comme standard – light KYC (Know-Your-Customer) – et permet au client d’acheter/vendre des crypto-monnaies jusqu’à une limite quotidienne définie. 
+L'inscription s'effectue généralement via l'adresse blockchain, en fournissant l'email ou le numéro de téléphone du client. Cet enregistrement est considéré comme standard – light KYC (Know-Your-Customer) – et permet au client d’acheter/vendre des crypto-monnaies jusqu’à une limite mensuelle définie (période glissante de 30 jours).
 
-Pour l'achat/vente de cryptomonnaies d'un montant supérieur àÉtant donné la limite quotidienne, un enregistrement plus détaillé est requis, ce qui est considéré comme un processus KYC (Know-Your-Customer) étendu et complet. Dans le cadre de ce processus, les informations suivantes doivent notamment être divulguées à DFX :
+Pour l'achat/vente de cryptomonnaies au-delà de cette limite mensuelle, un enregistrement plus détaillé est requis, ce qui est considéré comme un processus KYC (Know-Your-Customer) étendu et complet. Dans le cadre de ce processus, les informations suivantes doivent notamment être divulguées à DFX :
 
 * Adresse dont la preuve est apportée par l'envoi d'un courrier à l'adresse indiquée
 * Copie de la pièce d'identité (carte d'identité ou passeport), qui doit comporter une signature, un code MRZ lisible et une photo
@@ -213,7 +213,7 @@ Les itinéraires de vente peuvent être annulés tant que la cryptomonnaie à co
 
 Les frais de transaction des cryptomonnaies ou des devises étrangères transmis au client sont inclus dans le prix de base. Les prix sont indiqués dans la cryptomonnaie autorisée pour la transaction et incluent la TVA suisse, le cas échéant. Une fois le transfert de la cryptomonnaie ou de la devise étrangère souhaitée vers le portefeuille/compte du client effectué, la vente est considérée comme terminée. Le client reçoit un e-mail de confirmation de la finalisation de la transaction avec un aperçu de la transaction.
 
-DFX souligne qu'il existe un volume de ventes maximum par jour et par client. Le client a la possibilité de demander un volume de ventes plus élevé. Cette demande sera évaluée et discutée individuellement par DFX. 
+DFX souligne qu'il existe un volume de ventes maximum par mois (période glissante de 30 jours) et par client. Le client a la possibilité de demander un volume de ventes plus élevé. Cette demande sera évaluée et discutée individuellement par DFX. 
 
 Les remboursements des ventes aux clients DFX sont effectués exclusivement dans la crypto-monnaie initialement transférée. Le montant remboursé correspond exactement à la valeur qui a été transférée à DFX pour la vente.
 
@@ -237,7 +237,7 @@ Les dispositions suivantes s'appliquent :
   * Les manipulations techniques visant à tromper DFX sur le paiement ne sont pas autorisées et seront signalées. En particulier, les « doubles dépenses » ne sont pas autorisées et seront poursuivies comme fraude.
 
 DFX propose le paiement selon les normes suivantes :
-* FrankencoinPay et OpenCryptoPay
+* OpenCryptoPay
   * Paiements via Lightning BOLT11
     * L'utilisateur supporte les frais de routage.
     * Une contribution reçue de, par exemple, 1 BTC correspond à 1 BTC.

--- a/src/fr/tnc.md
+++ b/src/fr/tnc.md
@@ -213,7 +213,7 @@ Les itinéraires de vente peuvent être annulés tant que la cryptomonnaie à co
 
 Les frais de transaction des cryptomonnaies ou des devises étrangères transmis au client sont inclus dans le prix de base. Les prix sont indiqués dans la cryptomonnaie autorisée pour la transaction et incluent la TVA suisse, le cas échéant. Une fois le transfert de la cryptomonnaie ou de la devise étrangère souhaitée vers le portefeuille/compte du client effectué, la vente est considérée comme terminée. Le client reçoit un e-mail de confirmation de la finalisation de la transaction avec un aperçu de la transaction.
 
-DFX souligne qu'il existe un volume de ventes maximum par mois (période glissante de 30 jours) et par client. Le client a la possibilité de demander un volume de ventes plus élevé. Cette demande sera évaluée et discutée individuellement par DFX. 
+DFX souligne qu'il existe un volume de ventes maximum par mois (période glissante de 30 jours) et par client. Le client a la possibilité de demander un volume de ventes plus élevé. Cette demande sera évaluée et discutée individuellement par DFX.
 
 Les remboursements des ventes aux clients DFX sont effectués exclusivement dans la crypto-monnaie initialement transférée. Le montant remboursé correspond exactement à la valeur qui a été transférée à DFX pour la vente.
 
@@ -262,5 +262,5 @@ DFX propose le paiement selon les normes suivantes :
 Les tarifs des opérations de recouvrement de créances sont fixés comme suit :
 * DFX ne facture généralement aucun frais pour le règlement des demandes de recouvrement de créances.
 * DFX définit une adresse blockchain à laquelle le montant réclamé peut être transmis. Pour les paiements via Lightning, une facture BOLT11 est créée. Les frais de blockchain ou de routage Lightning doivent être supportés par l'utilisateur et ne font pas partie du service de recouvrement de créances de DFX. Ces frais sont variables.
-* Si l'utilisateur décide de payer dans une devise étrangère, DFX facture des frais de conversion de devise de 1 % si FrankencoinPay, Lightning BOLT11 ou OpenCryptoPay.io est sélectionné comme mode de paiement.  
+* Si l'utilisateur décide de payer dans une devise étrangère, DFX facture des frais de conversion de devise de 1 % si Lightning BOLT11 ou OpenCryptoPay.io est sélectionné comme mode de paiement.
 Pour toutes les autres options de paiement, telles que « PayToBlockchainAddress », des frais de conversion de devise de 2 % sont facturés. L'augmentation des frais est nécessaire car ces méthodes de paiement offrent une période de validité plus longue.

--- a/src/fr/tnc.md
+++ b/src/fr/tnc.md
@@ -14,7 +14,7 @@ En accédant et en utilisant le site Web et en téléchargeant des informations,
 
 ## Aucun conseil
 DFX ne fournit pas de conseils en investissement, fiscaux ou juridiques. Les informations fournies sur le site Internet sont fournies à titre informatif uniquement et ne constituent pas des recommandations. Les clients prennent leurs décisions d'investissement de manière indépendante et assument l'entière responsabilité des risques qui en découlent.  
-Cela s'applique à tous les services financiers proposés par DFX, qui incluent l'achat, la vente, l'échange et l'envoi de crypto-monnaies.  
+Cela s'applique à tous les services financiers proposés par DFX, qui incluent l'achat, la vente et l'échange de crypto-monnaies.  
 
 Toutes les décisions d'investissement prises par les clients reposent uniquement sur leur propre évaluation de leur situation financière et de leurs objectifs d'investissement. Ils sont seuls responsables de ces décisions et des conséquences qui en découlent. DFX fournit ses services exclusivement à la demande explicite et indépendante du client, sans vérifier sa situation financière, sa compréhension technique, l'adéquation ou l'opportunité de l'investissement.
 
@@ -65,7 +65,6 @@ Les services financiers de DFX comprennent :
 * Acheter
 * Vendre
 * Échange (Échange)
-* Envoyer
 
 Les options de paiement comprennent :
 * Virement bancaire
@@ -94,17 +93,6 @@ Veuillez vous abstenir de contacter directement la banque, car cela entraînerai
 ## Restrictions locales
 
 Les produits et services proposés sur ce site Internet sont uniquement autorisés à la vente en Suisse. Les personnes accédant au site Internet depuis l’étranger le font à leurs propres risques. DFX décline toute responsabilité liée à l'utilisation du site Internet en dehors de la Suisse. En particulier, il est rappelé que chaque utilisateur étranger est tenu de préciser s'il peut utiliser les services et produits proposés par DFX sur la base de la législation en vigueur à son lieu de résidence ou de son siège social ou sur la base de la législation de son pays d'origine.
-
-## Garde des actifs
-### Conditions de garde
-DFX propose la garde d'actifs aux clients. Les classes d'actifs suivantes sont éligibles : francs suisses (CHF), euros (EUR), Bitcoin (BTC) et Frankencoin Pool Shares (FPS). La garde de ces actifs est soumise aux conditions suivantes :
-* Flexibilité dans le choix de l'actif de conservation : Si un client décide de conserver un certain montant d'une classe d'actifs auprès de DFX, il est à la discrétion de DFX de décider dans quel type ou sur quelle blockchain cet actif est détenu.
-    * Exemple 1 : Si le client décide de conserver le BTC, DFX peut le conserver soit sur la chaîne principale Bitcoin, soit sous forme de Wrapped Bitcoin (WBTC) sur la blockchain Ethereum.
-    * Exemple 2 : Si le client choisit FPS, celui-ci peut être conservé soit en tant que FPS sur Ethereum, soit en tant que WFPS (Wrapped FPS) sur Polygon.  
-
-DFX se réserve cette flexibilité pour rendre la garde efficace et sécurisée. Tous les actifs détenus pour les clients sont séparés à une adresse spécifique au client. Les clients ont la possibilité de visualiser à tout moment via la [solution logicielle DFX](https://app.dfx.swiss/) qui adresse leur actifs sont conservés et sous quel type (actif et blockchain).
-
-La conservation est effectuée dans le respect de la réglementation suisse applicable, notamment en matière de sécurité et de protection des fonds de la clientèle. DFX veille à ce que les actifs détenus ne soient pas mélangés à ses propres actifs. Les actifs détenus sont toujours la propriété du client et ne tomberaient pas dans la masse de la faillite en cas d'insolvabilité.
 
 ## Traitement des données de transaction
 Pour toutes les transactions d’actifs numériques, les informations suivantes sont rendues publiques :
@@ -140,11 +128,7 @@ Au moins les informations suivantes sont requises :
 Pour les transactions blockchain de DFX vers des portefeuilles non auto-hébergés, ces données sont automatiquement transmises par DFX au fournisseur d'hébergement. Sauf accord contraire, les données sont transmises par email à Compliance(at)"provider.domain". Il est recommandé aux clients de DFX qui ne souhaitent pas accepter cette transmission d'utiliser un portefeuille auto-hébergé.
 
 ## Inscription des utilisateurs
-Avant de pouvoir utiliser les services financiers de DFX, le client doit s'inscrire. L'inscription est gratuite pour les particuliers et donne lieu, après acceptation des présentes conditions générales, à la création d'un profil d'utilisateur. Lorsqu'un client s'inscrit, les informations et documents que le client doit soumettre à DFX et le montant maximum pour lequel le client peut acheter ou vendre des crypto-monnaies dépendent de son niveau d'identification :
-
-L'inscription s'effectue généralement via l'adresse blockchain, en fournissant l'email ou le numéro de téléphone du client. Cet enregistrement est considéré comme standard – light KYC (Know-Your-Customer) – et permet au client d’acheter/vendre des crypto-monnaies jusqu’à une limite mensuelle définie (période glissante de 30 jours).
-
-Pour l'achat/vente de cryptomonnaies au-delà de cette limite mensuelle, un enregistrement plus détaillé est requis, ce qui est considéré comme un processus KYC (Know-Your-Customer) étendu et complet. Dans le cadre de ce processus, les informations suivantes doivent notamment être divulguées à DFX :
+Avant de pouvoir utiliser les services financiers de DFX, le client doit s'inscrire et terminer la vérification d'identité (KYC). L'inscription est gratuite pour les particuliers et donne lieu, après acceptation des présentes conditions générales, à la création d'un profil d'utilisateur. L'achat, la vente et l'échange ne sont possibles qu'après achèvement de la vérification d'identité. Dans le cadre de la vérification d'identité, les informations suivantes doivent notamment être divulguées à DFX :
 
 * Adresse dont la preuve est apportée par l'envoi d'un courrier à l'adresse indiquée
 * Copie de la pièce d'identité (carte d'identité ou passeport), qui doit comporter une signature, un code MRZ lisible et une photo
@@ -158,9 +142,9 @@ Les limites jusqu'où les achats/ventes de crypto-monnaies sont exécutés sont 
 
 DFX se réserve le droit de procéder à une vidéoconférence pour vérifier l'identité du client. Cela s'applique entre autres si DFX estime que les documents fournis sont incomplets, si le lieu de résidence ou d'activité du client se trouve dans un pays à risque ou si la première transaction effectuée par le client a été effectuée depuis un pays à risque ou via un compte bancaire qui n'est pas au nom du client.
 
-La soumission et la validation complètes et correctes de ces documents sont requises pour le premier achat et vente de cryptomonnaies ainsi que pour la conversion de cryptomonnaies, ou à tout moment sur demande de DFX sans indication de motifs.
+La soumission et la validation complètes et correctes de ces documents sont requises pour l'achat, la vente et l'échange de cryptomonnaies.
 
-Les données fournies doivent être complètes et valables à tout moment. Les modifications des données personnelles ainsi que toutes les données sous-jacentes au KYC léger ou complet doivent être communiquées sans délai à DFX par le client.
+Les données fournies doivent être complètes et valables à tout moment. Les modifications des données personnelles ainsi que toutes les données sous-jacentes au KYC doivent être communiquées sans délai à DFX par le client.
 
 Les employés de DFX ne demandent jamais au client des mots de passe, des clés privées ou des graines. De telles demandes doivent être ignorées et signalées à DFX.
 
@@ -216,51 +200,3 @@ Les frais de transaction des cryptomonnaies ou des devises étrangères transmis
 DFX souligne qu'il existe un volume de ventes maximum par mois (période glissante de 30 jours) et par client. Le client a la possibilité de demander un volume de ventes plus élevé. Cette demande sera évaluée et discutée individuellement par DFX.
 
 Les remboursements des ventes aux clients DFX sont effectués exclusivement dans la crypto-monnaie initialement transférée. Le montant remboursé correspond exactement à la valeur qui a été transférée à DFX pour la vente.
-
-## Programme de parrainage
-Notre programme de parrainage verse aux clients 0,25 % sur le volume d'achat/investissement acheté par un nouveau client via le lien de parrainage du client, ainsi que 0,1 % sur les transactions du lien de paiement. 
-
-Il est précisé que la participation au programme de parrainage n'est autorisée qu'aux clients DFX. Il est également précisé que le programme de parrainage peut être interrompu ou modifié à tout moment et sans préavis. De plus amples détails peuvent être consultés sur https://app.dfx.swiss/account. Il est précisé que ce lien ne fonctionne que si l'utilisateur s'est déjà connecté avec son compte client.
-
-Le programme de parrainage s'adresse aux clients résidant en Suisse et est destiné aux parrainages dans l'environnement personnel. Il n’établit pas de relation de représentation, de médiation ou de mandat. Le client n'est pas autorisé à agir au nom de DFX ni à faire des déclarations. La publicité ou la distribution publique ou payante/sponsorisée du code de parrainage ou des services DFX (par exemple via des sites Web ou des réseaux sociaux) n'est pas autorisée. Le client reconnaît que la transmission ou la publicité en dehors de la Suisse peut violer les réglementations locales. En cas de suspicion ou de preuve d'une infraction, DFX pourra bloquer la participation et refuser ou réclamer des avantages ou une rémunération. Le client indemnise DFX pour les dommages résultant d'une violation coupable de cette disposition, y compris les frais de justice raisonnables. Le client n'indemnise les amendes ou pénalités officielles que dans la mesure où cela est légalement autorisé et si elles sont directement causées par son comportement fautif.
-
-## Activité de recouvrement de créances
-
-## Portée et pprestations de l'activité de recouvrement de créances
-Les activités de recouvrement de créances de DFX comprennent :
-* Lien de paiement
-
-Les dispositions suivantes s'appliquent : 
-* Les parties contractantes qui souhaitent céder des créances à DFX via une activité de recouvrement de créances doivent y consentir au moyen d'un contrat séparé avec DFX. Sauf stipulation contraire au contrat, des frais de 0,1% sur le chiffre d'affaires s'appliquent.
-* Les utilisateurs qui décident de régler une créance impayée via le service de recouvrement de créances DFX peuvent le faire selon les conditions suivantes :
-  * Chaque réclamation a une période de validité définie, spécifiée en UTC. Le paiement doit être effectué dans ce délai.
-  * Les manipulations techniques visant à tromper DFX sur le paiement ne sont pas autorisées et seront signalées. En particulier, les « doubles dépenses » ne sont pas autorisées et seront poursuivies comme fraude.
-
-DFX propose le paiement selon les normes suivantes :
-* OpenCryptoPay
-  * Paiements via Lightning BOLT11
-    * L'utilisateur supporte les frais de routage.
-    * Une contribution reçue de, par exemple, 1 BTC correspond à 1 BTC.
-  * Paiements sur une blockchain basée sur EVM
-    * L'utilisateur supporte les frais de blockchain.
-    * Une contribution reçue de par exemple 1 ZCHF correspond à 1 ZCHF.
-  * Paiements sur une blockchain basée sur UTXO
-    * L'utilisateur supporte les frais de blockchain.
-    * Une contribution reçue de, par exemple, 1 BTC ne correspond pas à 1 BTC.
-      * Les frais de réception d'un UTXO sont en outre facturés à l'expéditeur, car DFX ne peut dépenser l'UTXO reçu que si les frais de transaction blockchain correspondants sont payés.
-      * DFX considère donc le montant techniquement reçu moins les frais de transaction blockchain actuels comme le montant effectivement reçu.
-
-* Paiements via Lightning BOLT11
-    * analogue à ci-dessus
-
-* PayToBlockchainAddress
-  * Paiements sur une blockchain basée sur EVM
-    * analogue à ci-dessus
-  * Paiements sur une blockchain basée sur UTXO
-    * analogue à ci-dessus
-
-Les tarifs des opérations de recouvrement de créances sont fixés comme suit :
-* DFX ne facture généralement aucun frais pour le règlement des demandes de recouvrement de créances.
-* DFX définit une adresse blockchain à laquelle le montant réclamé peut être transmis. Pour les paiements via Lightning, une facture BOLT11 est créée. Les frais de blockchain ou de routage Lightning doivent être supportés par l'utilisateur et ne font pas partie du service de recouvrement de créances de DFX. Ces frais sont variables.
-* Si l'utilisateur décide de payer dans une devise étrangère, DFX facture des frais de conversion de devise de 1 % si Lightning BOLT11 ou OpenCryptoPay.io est sélectionné comme mode de paiement.
-Pour toutes les autres options de paiement, telles que « PayToBlockchainAddress », des frais de conversion de devise de 2 % sont facturés. L'augmentation des frais est nécessaire car ces méthodes de paiement offrent une période de validité plus longue.

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -32,16 +32,97 @@ Potete contattarci in qualsiasi momento per questa e altre domande sul tema dell
 
 DFX non raccoglie dati aggiuntivi per valutare statisticamente il comportamento di navigazione e non utilizza nessuno dei cosiddetti programmi di analisi.
 
-## 2. Hosting
+## 2. Hosting e infrastruttura
 
-### Hosting con GitHub
+### API e piattaforma applicativa con Microsoft Azure
 
-Il nostro sito web è ospitato su [GitHub](https://github.com/). Per maggiori dettagli, consultare il sito web di GitHub:   
-[Condizioni d'uso di GitHub](https://docs.github.com/de/site-policy/github-terms/github-terms-of-service/).  
-[Informativa sulla privacy di GitHub](https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement/).  
+L'infrastruttura centrale di DFX — in particolare l'API (api.dfx.swiss), la piattaforma applicativa (app.dfx.swiss) e il database — è gestita su Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Tutti i dati personali trattati nell'ambito dell'utilizzo dei nostri servizi finanziari (compresi i dati dei clienti, i dati delle transazioni, i dati KYC e i documenti d'identità) sono archiviati ed elaborati sull'infrastruttura Azure.
+
+DFX utilizza Azure App Services, Azure Storage, Azure CDN e un database Microsoft SQL Server. Il trattamento dei dati avviene nei centri dati Azure europei. Microsoft ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. Il trasferimento dei dati negli USA (ove applicabile) avviene sulla base dello Swiss-US Data Privacy Framework e delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
+
+Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement) e le [condizioni dei servizi online Microsoft](https://www.microsoft.com/licensing/terms).
+
+### Sito informativo con All-Inkl
+
+Il sito informativo (dfx.swiss) e il sito di documentazione (docs.dfx.swiss) sono ospitati presso All-Inkl. Il fornitore è ALL-INKL.COM - Neue Medien Münnich, Inh. René Münnich, Hauptstrasse 68, 02742 Friedersdorf, Germania. Su questi siti non vengono trattati dati personali dei clienti.
+
+Per ulteriori dettagli, consultare la [politica sulla privacy di All-Inkl](https://all-inkl.com/datenschutzinformationen/).
 
 
-## 3. Note generali e informazioni obbligatorie
+## 3. Responsabili del trattamento e fornitori terzi
+
+DFX si avvale di diversi responsabili del trattamento esterni per la fornitura dei propri servizi. Questi trattano i dati personali esclusivamente su incarico e secondo le istruzioni di DFX. DFX garantisce attraverso accordi contrattuali che tutti i responsabili del trattamento mantengano un livello adeguato di protezione dei dati.
+
+### Verifica dell'identità (KYC) con Sumsub
+
+Per la verifica dell'identità legalmente richiesta (Know Your Customer, KYC), DFX utilizza il fornitore di servizi Sumsub (Sum and Substance Ltd., Inghilterra e Galles, Company No. 09688671) come responsabile del trattamento.
+
+#### Dati trattati
+
+Nell'ambito della verifica dell'identità, i seguenti dati personali vengono trasmessi a Sumsub ed elaborati da quest'ultimo:
+
+* Dati personali: nome, cognome, data di nascita, nazionalità
+* Indirizzo: via, numero civico, codice postale, città, paese
+* Documenti d'identità: passaporto, carta d'identità o altri documenti ufficiali (copie/foto)
+* Dati biometrici: immagini facciali (selfie), riconoscimento facciale e rilevamento della vitalità per la verifica dell'identità
+* Registrazioni video: nell'ambito dell'identificazione video (se necessario)
+
+#### Dati particolarmente sensibili (art. 5 lett. c LPD)
+
+I dati biometrici trattati nell'ambito della verifica dell'identità (geometria facciale, rilevamento della vitalità) sono classificati come dati personali particolarmente sensibili ai sensi dell'art. 5 lett. c LPD. Il trattamento di questi dati avviene esclusivamente sulla base del vostro consenso esplicito ai sensi dell'art. 6 cpv. 7 LPD, che fornite separatamente prima dell'inizio del processo di identificazione. Potete revocare questo consenso in qualsiasi momento con effetto per il futuro; tuttavia, la revoca comporterà l'impossibilità di completare la verifica dell'identità e di utilizzare determinati servizi di DFX.
+
+#### Trasferimento dei dati all'estero
+
+Sumsub ha sede in Inghilterra e Galles (Regno Unito). Il Regno Unito dispone di una decisione di adeguatezza del Consiglio federale svizzero ai sensi dell'art. 16 cpv. 1 LPD, che garantisce un livello adeguato di protezione dei dati senza necessità di garanzie aggiuntive.
+
+#### Durata di conservazione
+
+I documenti e i dati biometrici raccolti nell'ambito della verifica dell'identità vengono conservati da DFX per il periodo di conservazione legale di 10 anni dalla cessazione del rapporto commerciale (art. 7 LRD). I dati biometrici grezzi presso Sumsub vengono cancellati secondo gli accordi contrattuali al termine della verifica.
+
+Per ulteriori informazioni sulla protezione dei dati presso Sumsub, consultare la [politica sulla privacy di Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Prevenzione delle frodi con Sift
+
+DFX utilizza il fornitore di servizi Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) come responsabile del trattamento per la prevenzione delle frodi e la lotta al riciclaggio di denaro.
+
+#### Dati trattati
+
+I seguenti dati vengono trasmessi a Sift nell'ambito della prevenzione delle frodi:
+
+* Informazioni sull'account: ID utente, data di creazione, livello KYC
+* Dati delle transazioni: importo, valuta, metodo di pagamento (ultime 4 cifre della carta di credito o prime 6 e ultime 4 cifre dell'IBAN), indirizzo blockchain
+* Dati tecnici: indirizzo IP, informazioni sul dispositivo, tipo di browser
+* Dati di accesso: orario e tipo di accesso
+
+#### Trasferimento dei dati all'estero
+
+Sift ha sede negli USA. Il trasferimento dei dati avviene sulla base dello Swiss-US Data Privacy Framework, nella misura in cui Sift è certificato ai sensi di tale quadro, o sulla base di clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
+
+Per ulteriori informazioni, consultare la [politica sulla privacy di Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Controllo delle sanzioni con Dilisense
+
+DFX utilizza il fornitore di servizi Dilisense per il controllo dei clienti rispetto alle liste di sanzioni, alle liste PEP (persone politicamente esposte) e ai casellari giudiziari. Nell'ambito di questo controllo vengono trasmessi il nome, la data di nascita e la nazionalità del cliente.
+
+### Monitoraggio lato server con Azure Application Insights
+
+DFX utilizza Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) a scopo di monitoraggio operativo, rilevamento degli errori e ottimizzazione delle prestazioni dell'infrastruttura API. Application Insights non è uno strumento di analisi del sito web per il tracciamento del comportamento degli utenti, ma uno strumento di monitoraggio lato server.
+
+#### Dati trattati
+
+* Dati tecnici delle richieste: percorsi URL, codici di stato HTTP, tempi di risposta
+* Registri di errori ed eccezioni: tracce dello stack, messaggi di errore
+* Dipendenze: chiamate a database e servizi esterni
+* Indirizzi IP: nell'ambito dell'elaborazione delle richieste
+
+Nessun contenuto personale (come nomi, indirizzi o dati finanziari) viene trasmesso ad Application Insights.
+
+#### Trasferimento dei dati all'estero
+
+Microsoft può elaborare i dati in centri dati al di fuori della Svizzera (UE/USA). Il trasferimento dei dati avviene sulla base delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD e dello Swiss-US Data Privacy Framework. Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement).
+
+
+## 4. Note generali e informazioni obbligatorie
 
 ### Protezione dei dati
 
@@ -72,7 +153,17 @@ Il sito DFX.swiss memorizza ed elabora solo i dati minimi necessari per il funzi
 
 ### Nota sul trasferimento dei dati all'estero
 
-Per l'hosting utilizziamo GitHub, una società statunitense. Quando si accede a questi strumenti, i vostri dati personali vengono trasferiti in questo paese terzo e potrebbero essere trattati in tale paese. Desideriamo sottolineare che in questi Paesi non è possibile garantire un livello di protezione dei dati paragonabile a quello svizzero. Ad esempio, le aziende statunitensi sono obbligate a consegnare i dati personali alle autorità di sicurezza senza che voi, in quanto interessati, possiate intraprendere azioni legali contro di esse. Non si può quindi escludere che le autorità statunitensi (ad esempio i servizi di intelligence) elaborino, valutino e conservino permanentemente i vostri dati su server statunitensi a scopo di monitoraggio. Non abbiamo alcuna influenza su queste attività di elaborazione.
+Nell'ambito delle nostre attività commerciali, i dati personali vengono trasferiti a destinatari nei seguenti paesi:
+
+| Destinatario | Paese | Finalità | Base giuridica |
+|-------------|-------|----------|----------------|
+| Microsoft Corporation (Azure) | UE / USA | Hosting dell'API, database, piattaforma applicativa, monitoraggio | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
+| Sumsub (Sum and Substance Ltd.) | Regno Unito | Verifica dell'identità (KYC) | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
+| Sift Science, Inc. | USA | Prevenzione delle frodi | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
+| Dilisense | UE | Controllo sanzioni e PEP | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
+| All-Inkl (ALL-INKL.COM - Neue Medien Münnich) | Germania (UE) | Hosting del sito informativo (nessun dato cliente) | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
+
+DFX trasferisce dati personali solo verso paesi che dispongono di un livello adeguato di protezione dei dati (ai sensi dell'allegato 1 dell'ordinanza sulla protezione dei dati), o applicando garanzie adeguate come le clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Inoltre, nell'ambito delle transazioni bancarie, i dati dei clienti possono essere trasferiti alle banche partecipanti in Svizzera e all'estero (cfr. Condizioni generali).
 
 ### Revoca del consenso al trattamento dei dati
 
@@ -118,7 +209,7 @@ Se avete limitato il trattamento dei vostri dati personali, questi potranno esse
 Con la presente ci si oppone all'utilizzo dei dati di contatto pubblicati nell'ambito dell'obbligo di imprinting per l'invio di materiale pubblicitario e informativo non espressamente richiesto. I gestori delle pagine si riservano espressamente il diritto di intraprendere azioni legali in caso di invio non richiesto di informazioni pubblicitarie, ad esempio tramite e-mail di spam.
 
 
-## 4. Raccolta di dati su questo sito web
+## 5. Raccolta di dati su questo sito web
 
 ### Cookie
 
@@ -140,11 +231,13 @@ Il trattamento di questi dati si basa sull'Art. 6 (1) lit. b DSGVO, se la vostra
 
 I dati che ci inviate tramite le richieste di contatto rimarranno presso di noi fino a quando non ci chiederete di cancellarli, non revocherete il vostro consenso alla loro memorizzazione o non verrà meno lo scopo della loro memorizzazione (ad es. dopo l'elaborazione della vostra richiesta). Le disposizioni di legge obbligatorie - in particolare i periodi di conservazione legale - rimangono inalterate.
 
-## 5. strumenti di analisi e pubblicità
+## 6. Strumenti di analisi e pubblicità
 
-DFX non utilizza strumenti di analisi come Google Analytics.
+DFX non utilizza strumenti di analisi del sito web per il tracciamento del comportamento degli utenti, come Google Analytics, Adobe Analytics o servizi comparabili. Non vengono utilizzati pixel di tracciamento, cookie pubblicitari o tecnologie simili per l'analisi del comportamento degli utenti.
 
-## 6. Newsletter
+Per il monitoraggio operativo lato server dell'infrastruttura API, DFX utilizza Microsoft Azure Application Insights (vedi sezione 3 «Responsabili del trattamento e fornitori terzi»). Questo strumento viene utilizzato esclusivamente per il monitoraggio tecnico, il rilevamento degli errori e l'ottimizzazione delle prestazioni e non raccoglie dati sul comportamento degli utenti sul sito web.
+
+## 7. Newsletter
 
 ### Dati della newsletter
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -180,7 +180,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi soltanto a Cloudflare (USA, accesso ai servizi) e ai responsabili del trattamento indicati sopra. Inoltre, nell'ambito delle transazioni bancarie, i dati dei clienti possono essere trasferiti alle banche partecipanti in Svizzera e all'estero (cfr. Condizioni generali).
+I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
 
 ### Crittografia SSL o TLS
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -452,7 +452,7 @@ Riferimenti e collegamenti a siti Web di terzi non rientrano nella responsabilit
 Tutte le offerte pubblicate da DFX in formato digitale o elettronico sono soggette a modifiche. DFX si riserva espressamente il diritto di modificare, integrare o eliminare parti delle pagine o l'intera offerta senza preavviso o di cessare la pubblicazione.attivo temporaneamente o permanentemente.
 
 
-## 16. Diritto d'autore e proprietà intellettuale 
+## 16. Diritto d'autore e proprietà intellettuale
 
 Il copyright e tutti gli altri diritti su contenuti, immagini, foto o altri file sul sito web DFX appartengono esclusivamente a DFX e alle sue società affiliate, ai loro fornitori o ai titolari dei diritti specificatamente nominati.
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -122,92 +122,20 @@ Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere info
 
 ## 4. Hosting e infrastruttura
 
-### Hosting con Cloudflare Pages
+DFX gestisce l'API, la piattaforma applicativa e il database su server propri in Svizzera.
 
-Ospitiamo il nostro sito Web con Cloudflare Pages. Il fornitore è Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (di seguito: Cloudflare).
+L'accesso pubblico ai nostri siti e servizi avviene tramite Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) come content delivery network e reverse proxy. All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i metadati della richiesta) vengono trasmessi a Cloudflare.
 
-Cloudflare ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. I dettagli sul trattamento dei dati personali sono disponibili nell'[informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/). Il trattamento per nostro conto si basa sul [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
-
-### API e piattaforma applicativa con Microsoft Azure
-
-L'infrastruttura centrale di DFX — in particolare l'API (api.dfx.swiss), la piattaforma applicativa (app.dfx.swiss) e il database — è gestita su Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Tutti i dati personali trattati nell'ambito dell'utilizzo dei nostri servizi finanziari (compresi i dati dei clienti, i dati delle transazioni, i dati KYC e i documenti d'identità) sono archiviati ed elaborati sull'infrastruttura Azure.
-
-DFX utilizza Azure App Services, Azure Storage, Azure CDN e un database Microsoft SQL Server. Il trattamento dei dati avviene nei centri dati Azure europei. Microsoft ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. Il trasferimento dei dati negli USA (ove applicabile) avviene sulla base dello Swiss-US Data Privacy Framework e delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
-
-Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement) e le [condizioni dei servizi online Microsoft](https://www.microsoft.com/licensing/terms).
+Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Dettagli: [informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/) e [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
-## 5. Responsabili del trattamento e fornitori terzi
+## 5. Responsabili del trattamento
 
-DFX si avvale di diversi responsabili del trattamento esterni per la fornitura dei propri servizi. Questi trattano i dati personali esclusivamente su incarico e secondo le istruzioni di DFX. DFX garantisce attraverso accordi contrattuali che tutti i responsabili del trattamento mantengano un livello adeguato di protezione dei dati.
+Ove necessario per l'esecuzione del contratto o per adempiere obblighi di legge, utilizziamo i seguenti responsabili del trattamento:
 
-### Verifica dell'identità (KYC) con Sumsub
-
-Per la verifica dell'identità legalmente richiesta (Know Your Customer, KYC), DFX utilizza il fornitore di servizi Sumsub (Sum and Substance Ltd., Inghilterra e Galles, Company No. 09688671) come responsabile del trattamento.
-
-#### Dati trattati
-
-Nell'ambito della verifica dell'identità, i seguenti dati personali vengono trasmessi a Sumsub ed elaborati da quest'ultimo:
-
-* Dati personali: nome, cognome, data di nascita, nazionalità
-* Indirizzo: via, numero civico, codice postale, città, paese
-* Documenti d'identità: passaporto, carta d'identità o altri documenti ufficiali (copie/foto)
-* Dati biometrici: immagini facciali (selfie), riconoscimento facciale e rilevamento della vitalità per la verifica dell'identità
-* Registrazioni video: nell'ambito dell'identificazione video (se necessario)
-
-#### Dati particolarmente sensibili (art. 5 lett. c LPD)
-
-I dati biometrici trattati nell'ambito della verifica dell'identità (geometria facciale, rilevamento della vitalità) sono classificati come dati personali particolarmente sensibili ai sensi dell'art. 5 lett. c LPD. Il trattamento di questi dati avviene esclusivamente sulla base del vostro consenso esplicito ai sensi dell'art. 6 cpv. 7 LPD, che fornite separatamente prima dell'inizio del processo di identificazione. Potete revocare questo consenso in qualsiasi momento con effetto per il futuro; tuttavia, la revoca comporterà l'impossibilità di completare la verifica dell'identità e di utilizzare determinati servizi di DFX.
-
-#### Trasferimento dei dati all'estero
-
-Sumsub ha sede in Inghilterra e Galles (Regno Unito). Il Regno Unito dispone di una decisione di adeguatezza del Consiglio federale svizzero ai sensi dell'art. 16 cpv. 1 LPD, che garantisce un livello adeguato di protezione dei dati senza necessità di garanzie aggiuntive.
-
-#### Durata di conservazione
-
-I documenti e i dati biometrici raccolti nell'ambito della verifica dell'identità vengono conservati da DFX per il periodo di conservazione legale di 10 anni dalla cessazione del rapporto commerciale (art. 7 LRD). I dati biometrici grezzi presso Sumsub vengono cancellati secondo gli accordi contrattuali al termine della verifica.
-
-Per ulteriori informazioni sulla protezione dei dati presso Sumsub, consultare la [politica sulla privacy di Sumsub](https://sumsub.com/privacy-notice-service/).
-
-### Prevenzione delle frodi con Sift
-
-DFX utilizza il fornitore di servizi Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) come responsabile del trattamento per la prevenzione delle frodi e la lotta al riciclaggio di denaro.
-
-#### Dati trattati
-
-I seguenti dati vengono trasmessi a Sift nell'ambito della prevenzione delle frodi:
-
-* Informazioni sull'account: ID utente, data di creazione, livello KYC
-* Dati delle transazioni: importo, valuta, metodo di pagamento (ultime 4 cifre della carta di credito o prime 6 e ultime 4 cifre dell'IBAN), indirizzo blockchain
-* Dati tecnici: indirizzo IP, informazioni sul dispositivo, tipo di browser
-* Dati di accesso: orario e tipo di accesso
-
-#### Trasferimento dei dati all'estero
-
-Sift ha sede negli USA. Il trasferimento dei dati avviene sulla base dello Swiss-US Data Privacy Framework, nella misura in cui Sift è certificato ai sensi di tale quadro, o sulla base di clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
-
-Per ulteriori informazioni, consultare la [politica sulla privacy di Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
-
-### Controllo delle sanzioni con Dilisense
-
-DFX utilizza il fornitore di servizi Dilisense per il controllo dei clienti rispetto alle liste di sanzioni, alle liste PEP (persone politicamente esposte) e ai casellari giudiziari. Nell'ambito di questo controllo vengono trasmessi il nome, la data di nascita e la nazionalità del cliente.
-
-### Monitoraggio lato server con Azure Application Insights
-
-DFX utilizza Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) a scopo di monitoraggio operativo, rilevamento degli errori e ottimizzazione delle prestazioni dell'infrastruttura API. Application Insights non è uno strumento di analisi del sito web per il tracciamento del comportamento degli utenti, ma uno strumento di monitoraggio lato server.
-
-#### Dati trattati
-
-* Dati tecnici delle richieste: percorsi URL, codici di stato HTTP, tempi di risposta
-* Registri di errori ed eccezioni: tracce dello stack, messaggi di errore
-* Dipendenze: chiamate a database e servizi esterni
-* Indirizzi IP: nell'ambito dell'elaborazione delle richieste
-
-Nessun contenuto personale (come nomi, indirizzi o dati finanziari) viene trasmesso ad Application Insights.
-
-#### Trasferimento dei dati all'estero
-
-Microsoft può elaborare i dati in centri dati al di fuori della Svizzera (UE/USA). Il trasferimento dei dati avviene sulla base delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD e dello Swiss-US Data Privacy Framework. Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement).
+* Sumsub (Sum and Substance Ltd., Regno Unito) — verifica dell'identità prescritta dalla legge, compresi documenti d'identità e dati biometrici. Il Regno Unito dispone di una decisione di adeguatezza (art. 16 cpv. 1 LPD). Trattiamo i dati biometrici solo con il vostro consenso esplicito (art. 6 cpv. 7 LPD).
+* Sift Science, Inc. (USA) — prevenzione delle frodi. Il trasferimento si basa sullo Swiss-U.S. Data Privacy Framework o su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD).
+* Dilisense (UE) — controllo delle liste di sanzioni e PEP. Decisione di adeguatezza (art. 16 cpv. 1 LPD).
 
 
 ## 6. Note generali e informazioni obbligatorie
@@ -253,21 +181,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-Per l'hosting utilizziamo Cloudflare Pages, un servizio fornito da Cloudflare, Inc., con sede negli Stati Uniti. Quando accedete al nostro sito Web, i dati tecnicamente necessari (in particolare il vostro indirizzo IP e i metadati della richiesta) vengono trasferiti negli Stati Uniti e ivi elaborati, poiché Cloudflare termina la connessione come reverse proxy / Content Delivery Network.
-
-Base giuridica per il trasferimento dei dati negli Stati Uniti: Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo sulle clausole contrattuali standard della Commissione Europea. Nonostante queste garanzie, non si può escludere completamente un accesso da parte delle autorità statunitensi (ad esempio ai sensi del CLOUD Act).
-
-Nell'ambito delle nostre attività commerciali, i dati personali vengono trasferiti a destinatari nei seguenti paesi:
-
-| Destinatario | Paese | Finalità | Base giuridica |
-|-------------|-------|----------|----------------|
-| Microsoft Corporation (Azure) | UE / USA | Hosting dell'API, database, piattaforma applicativa, monitoraggio | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
-| Sumsub (Sum and Substance Ltd.) | Regno Unito | Verifica dell'identità (KYC) | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
-| Sift Science, Inc. | USA | Prevenzione delle frodi | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
-| Dilisense | UE | Controllo sanzioni e PEP | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
-| Cloudflare, Inc. | USA | Hosting del sito web e della documentazione (Cloudflare Pages) | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
-
-DFX trasferisce dati personali solo verso paesi che dispongono di un livello adeguato di protezione dei dati (ai sensi dell'allegato 1 dell'ordinanza sulla protezione dei dati), o applicando garanzie adeguate come le clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Inoltre, nell'ambito delle transazioni bancarie, i dati dei clienti possono essere trasferiti alle banche partecipanti in Svizzera e all'estero (cfr. Condizioni generali).
+I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi soltanto a Cloudflare (USA, accesso ai servizi) e ai responsabili del trattamento indicati sopra. Inoltre, nell'ambito delle transazioni bancarie, i dati dei clienti possono essere trasferiti alle banche partecipanti in Svizzera e all'estero (cfr. Condizioni generali).
 
 ### Crittografia SSL o TLS
 
@@ -337,8 +251,6 @@ I dati che ci invii tramite richieste di contatto rimarranno con noi fino a quan
 ## 9. Strumenti di analisi e pubblicità
 
 DFX non utilizza strumenti di analisi del sito web come Google Analytics, Adobe Analytics o altri. Non vengono utilizzati pixel di tracciamento, cookie pubblicitari o tecnologie simili per l'analisi del comportamento degli utenti.
-
-Per il monitoraggio operativo lato server dell'infrastruttura API, DFX utilizza Microsoft Azure Application Insights (vedi sezione 5 «Responsabili del trattamento e fornitori terzi»). Questo strumento viene utilizzato esclusivamente per il monitoraggio tecnico, il rilevamento degli errori e l'ottimizzazione delle prestazioni e non raccoglie dati sul comportamento degli utenti sul sito web.
 
 
 ## 10. Newsletter e social media

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -306,7 +306,7 @@ In caso di violazione della protezione dei dati, DFX segue una procedura struttu
 
 #### Obblighi di notifica
 
-In caso di violazione della protezione dei dati che rappresenta un rischio per i diritti e le libertà degli interessati, DFX è legalmente obbligata a informare determinate parti. Tali notifiche hanno lo scopo di garantire che sia le autorità competenti che le autorità competentiGli interessati sono informati tempestivamente della violazione e delle misure adottate. Le notifiche vengono effettuate in conformità ai requisiti legali e comprendono le seguenti fasi:
+In caso di violazione della protezione dei dati che comporta presumibilmente un rischio elevato per la personalità o i diritti fondamentali degli interessati, DFX è legalmente obbligata a informare determinate parti. Tali notifiche hanno lo scopo di garantire che sia le autorità competenti sia gli interessati siano informati tempestivamente della violazione e delle misure adottate. Le notifiche vengono effettuate in conformità ai requisiti legali e comprendono le seguenti fasi:
 
 * Notifica all'autorità di vigilanza competente (IFPDT) il più rapidamente possibile dopo la conoscenza della violazione (art. 24 cpv. 1 LPD).
 * Notifica agli interessati, se ciò è necessario per la loro protezione o se l'IFPDT lo richiede (art. 24 cpv. 4 LPD), senza ritardo e in un linguaggio chiaro e comprensibile.
@@ -336,7 +336,7 @@ I dati che ci invii tramite richieste di contatto rimarranno con noi fino a quan
 
 ## 9. Strumenti di analisi e pubblicità
 
-DFX non utilizza strumenti di analisi del sito web come Google Analytics, Adobe Analytics o altri.
+DFX non utilizza strumenti di analisi del sito web come Google Analytics, Adobe Analytics o altri. Non vengono utilizzati pixel di tracciamento, cookie pubblicitari o tecnologie simili per l'analisi del comportamento degli utenti.
 
 Per il monitoraggio operativo lato server dell'infrastruttura API, DFX utilizza Microsoft Azure Application Insights (vedi sezione 5 «Responsabili del trattamento e fornitori terzi»). Questo strumento viene utilizzato esclusivamente per il monitoraggio tecnico, il rilevamento degli errori e l'ottimizzazione delle prestazioni e non raccoglie dati sul comportamento degli utenti sul sito web.
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -249,7 +249,7 @@ I dati che ci invii tramite richieste di contatto rimarranno con noi fino a quan
 
 ## 9. Strumenti di analisi e pubblicità
 
-DFX non utilizza strumenti di analisi del sito web come Google Analytics, Adobe Analytics o altri. Non vengono utilizzati pixel di tracciamento, cookie pubblicitari o tecnologie simili per l'analisi del comportamento degli utenti.
+DFX non utilizza strumenti di analisi del sito web per il tracciamento del comportamento degli utenti, come Google Analytics, Adobe Analytics o servizi comparabili. Non vengono utilizzati pixel di tracciamento, cookie pubblicitari o tecnologie simili per l'analisi del comportamento degli utenti.
 
 
 ## 10. Newsletter e social media

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -134,7 +134,6 @@ Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https:/
 Ove necessario per l'esecuzione del contratto o per adempiere obblighi di legge, utilizziamo i seguenti responsabili del trattamento:
 
 * Sumsub (Sum and Substance Ltd., Regno Unito) — verifica dell'identità prescritta dalla legge, compresi documenti d'identità e dati biometrici. Il Regno Unito dispone di una decisione di adeguatezza (art. 16 cpv. 1 LPD). Trattiamo i dati biometrici solo con il vostro consenso esplicito (art. 6 cpv. 7 LPD).
-* Sift Science, Inc. (USA) — prevenzione delle frodi. Il trasferimento si basa sullo Swiss-U.S. Data Privacy Framework o su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD).
 * Dilisense (UE) — controllo delle liste di sanzioni e PEP. Decisione di adeguatezza (art. 16 cpv. 1 LPD).
 
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -134,7 +134,7 @@ All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i me
 Ove necessario per l'esecuzione del contratto o per adempiere obblighi di legge, utilizziamo i seguenti responsabili del trattamento:
 
 * Sumsub (Sum and Substance Ltd., Regno Unito) — verifica dell'identità prescritta dalla legge, compresi documenti d'identità e dati biometrici. Il Regno Unito dispone di una decisione di adeguatezza (art. 16 cpv. 1 LPD). Trattiamo i dati biometrici solo con il vostro consenso esplicito (art. 6 cpv. 7 LPD).
-* Dilisense (UE) — controllo delle liste di sanzioni e PEP. Decisione di adeguatezza (art. 16 cpv. 1 LPD).
+* Dilisense (Svizzera) — controllo delle liste di sanzioni e PEP.
 
 
 ## 6. Note generali e informazioni obbligatorie

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -224,7 +224,7 @@ In caso di violazione della protezione dei dati che comporta presumibilmente un 
 
 * Notifica all'autorità di vigilanza competente (IFPDT) il più rapidamente possibile dopo la conoscenza della violazione (art. 24 cpv. 1 LPD).
 * Notifica agli interessati, se ciò è necessario per la loro protezione o se l'IFPDT lo richiede (art. 24 cpv. 4 LPD), senza ritardo e in un linguaggio chiaro e comprensibile.
-* I responsabili del trattamento di DFX (come Sumsub, Sift e altri) sono contrattualmente obbligati a informare DFX immediatamente delle violazioni della protezione dei dati (art. 24 cpv. 3 LPD).
+* I responsabili del trattamento indicati sopra sono contrattualmente obbligati a informare DFX immediatamente delle violazioni della protezione dei dati (art. 24 cpv. 3 LPD).
    
 ### Misure di protezione
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -122,11 +122,11 @@ Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere info
 
 ## 4. Hosting e infrastruttura
 
-DFX gestisce l'API, la piattaforma applicativa e il database su server propri in Svizzera.
+DFX ospita i siti web statici senza dati dei clienti (ad esempio dfx.swiss) presso Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
 
-L'accesso pubblico ai nostri siti e servizi avviene tramite Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA) come content delivery network e reverse proxy. All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i metadati della richiesta) vengono trasmessi a Cloudflare.
+DFX gestisce l'API, la piattaforma applicativa e il database su server propri in Svizzera. L'accesso pubblico a questi servizi avviene tramite Cloudflare come content delivery network e reverse proxy.
 
-Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Dettagli: [informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/) e [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
+All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i metadati della richiesta) vengono trasmessi a Cloudflare. Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Dettagli: [informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/) e [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Responsabili del trattamento
@@ -180,7 +180,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
+I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting dei siti statici e accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
 
 ### Crittografia SSL o TLS
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -124,7 +124,7 @@ Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere info
 
 DFX ospita le pagine informative statiche che non raccolgono dati dei clienti (ad esempio dfx.swiss) presso Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Su queste pagine non ci sono conti clienti, transazioni né verifica dell'identità.
 
-Tutto ciò che tratta dati dei clienti — l'API, la piattaforma applicativa e il database — è gestito da DFX su server propri in Svizzera. L'accesso pubblico a questi servizi avviene tramite Cloudflare come content delivery network e reverse proxy.
+DFX gestisce l'API, la piattaforma applicativa e il database su server propri in Svizzera. L'accesso pubblico a questi servizi avviene tramite Cloudflare come content delivery network e reverse proxy.
 
 All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i metadati della richiesta) vengono trasmessi a Cloudflare. Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Dettagli: [informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/) e [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting delle pagine statiche senza dati dei clienti e accesso ai servizi), a Sumsub (Regno Unito) e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
+I dati dei clienti della piattaforma di negoziazione sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting delle pagine statiche senza dati dei clienti e accesso ai servizi), a Sumsub (Regno Unito) e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali). I trasferimenti da parte dei social media indicati sotto sono descritti nella sezione 10.
 
 ### Crittografia SSL o TLS
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -120,7 +120,7 @@ DFX non esegue processi decisionali puramente automatizzati che sono giuridicame
 Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere informazioni sulla logica sottostante e sugli effetti della profilazione su di loro.
 
 
-## 4. Ospitalità
+## 4. Hosting e infrastruttura
 
 ### Hosting con Cloudflare Pages
 
@@ -128,8 +128,89 @@ Ospitiamo il nostro sito Web con Cloudflare Pages. Il fornitore è Cloudflare, I
 
 Cloudflare ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. I dettagli sul trattamento dei dati personali sono disponibili nell'[informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/). Il trattamento per nostro conto si basa sul [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
+### API e piattaforma applicativa con Microsoft Azure
 
-##5. Note generali e informazioni obbligatorie
+L'infrastruttura centrale di DFX — in particolare l'API (api.dfx.swiss), la piattaforma applicativa (app.dfx.swiss) e il database — è gestita su Microsoft Azure (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA). Tutti i dati personali trattati nell'ambito dell'utilizzo dei nostri servizi finanziari (compresi i dati dei clienti, i dati delle transazioni, i dati KYC e i documenti d'identità) sono archiviati ed elaborati sull'infrastruttura Azure.
+
+DFX utilizza Azure App Services, Azure Storage, Azure CDN e un database Microsoft SQL Server. Il trattamento dei dati avviene nei centri dati Azure europei. Microsoft ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. Il trasferimento dei dati negli USA (ove applicabile) avviene sulla base dello Swiss-US Data Privacy Framework e delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
+
+Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement) e le [condizioni dei servizi online Microsoft](https://www.microsoft.com/licensing/terms).
+
+
+## 5. Responsabili del trattamento e fornitori terzi
+
+DFX si avvale di diversi responsabili del trattamento esterni per la fornitura dei propri servizi. Questi trattano i dati personali esclusivamente su incarico e secondo le istruzioni di DFX. DFX garantisce attraverso accordi contrattuali che tutti i responsabili del trattamento mantengano un livello adeguato di protezione dei dati.
+
+### Verifica dell'identità (KYC) con Sumsub
+
+Per la verifica dell'identità legalmente richiesta (Know Your Customer, KYC), DFX utilizza il fornitore di servizi Sumsub (Sum and Substance Ltd., Inghilterra e Galles, Company No. 09688671) come responsabile del trattamento.
+
+#### Dati trattati
+
+Nell'ambito della verifica dell'identità, i seguenti dati personali vengono trasmessi a Sumsub ed elaborati da quest'ultimo:
+
+* Dati personali: nome, cognome, data di nascita, nazionalità
+* Indirizzo: via, numero civico, codice postale, città, paese
+* Documenti d'identità: passaporto, carta d'identità o altri documenti ufficiali (copie/foto)
+* Dati biometrici: immagini facciali (selfie), riconoscimento facciale e rilevamento della vitalità per la verifica dell'identità
+* Registrazioni video: nell'ambito dell'identificazione video (se necessario)
+
+#### Dati particolarmente sensibili (art. 5 lett. c LPD)
+
+I dati biometrici trattati nell'ambito della verifica dell'identità (geometria facciale, rilevamento della vitalità) sono classificati come dati personali particolarmente sensibili ai sensi dell'art. 5 lett. c LPD. Il trattamento di questi dati avviene esclusivamente sulla base del vostro consenso esplicito ai sensi dell'art. 6 cpv. 7 LPD, che fornite separatamente prima dell'inizio del processo di identificazione. Potete revocare questo consenso in qualsiasi momento con effetto per il futuro; tuttavia, la revoca comporterà l'impossibilità di completare la verifica dell'identità e di utilizzare determinati servizi di DFX.
+
+#### Trasferimento dei dati all'estero
+
+Sumsub ha sede in Inghilterra e Galles (Regno Unito). Il Regno Unito dispone di una decisione di adeguatezza del Consiglio federale svizzero ai sensi dell'art. 16 cpv. 1 LPD, che garantisce un livello adeguato di protezione dei dati senza necessità di garanzie aggiuntive.
+
+#### Durata di conservazione
+
+I documenti e i dati biometrici raccolti nell'ambito della verifica dell'identità vengono conservati da DFX per il periodo di conservazione legale di 10 anni dalla cessazione del rapporto commerciale (art. 7 LRD). I dati biometrici grezzi presso Sumsub vengono cancellati secondo gli accordi contrattuali al termine della verifica.
+
+Per ulteriori informazioni sulla protezione dei dati presso Sumsub, consultare la [politica sulla privacy di Sumsub](https://sumsub.com/privacy-notice-service/).
+
+### Prevenzione delle frodi con Sift
+
+DFX utilizza il fornitore di servizi Sift Science, Inc. (123 Mission Street, Suite 2000, San Francisco, CA 94105, USA) come responsabile del trattamento per la prevenzione delle frodi e la lotta al riciclaggio di denaro.
+
+#### Dati trattati
+
+I seguenti dati vengono trasmessi a Sift nell'ambito della prevenzione delle frodi:
+
+* Informazioni sull'account: ID utente, data di creazione, livello KYC
+* Dati delle transazioni: importo, valuta, metodo di pagamento (ultime 4 cifre della carta di credito o prime 6 e ultime 4 cifre dell'IBAN), indirizzo blockchain
+* Dati tecnici: indirizzo IP, informazioni sul dispositivo, tipo di browser
+* Dati di accesso: orario e tipo di accesso
+
+#### Trasferimento dei dati all'estero
+
+Sift ha sede negli USA. Il trasferimento dei dati avviene sulla base dello Swiss-US Data Privacy Framework, nella misura in cui Sift è certificato ai sensi di tale quadro, o sulla base di clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD.
+
+Per ulteriori informazioni, consultare la [politica sulla privacy di Sift](https://sift.com/legal-and-compliance/service-privacy-notice).
+
+### Controllo delle sanzioni con Dilisense
+
+DFX utilizza il fornitore di servizi Dilisense per il controllo dei clienti rispetto alle liste di sanzioni, alle liste PEP (persone politicamente esposte) e ai casellari giudiziari. Nell'ambito di questo controllo vengono trasmessi il nome, la data di nascita e la nazionalità del cliente.
+
+### Monitoraggio lato server con Azure Application Insights
+
+DFX utilizza Microsoft Azure Application Insights (Microsoft Corporation, One Microsoft Way, Redmond, WA 98052, USA) a scopo di monitoraggio operativo, rilevamento degli errori e ottimizzazione delle prestazioni dell'infrastruttura API. Application Insights non è uno strumento di analisi del sito web per il tracciamento del comportamento degli utenti, ma uno strumento di monitoraggio lato server.
+
+#### Dati trattati
+
+* Dati tecnici delle richieste: percorsi URL, codici di stato HTTP, tempi di risposta
+* Registri di errori ed eccezioni: tracce dello stack, messaggi di errore
+* Dipendenze: chiamate a database e servizi esterni
+* Indirizzi IP: nell'ambito dell'elaborazione delle richieste
+
+Nessun contenuto personale (come nomi, indirizzi o dati finanziari) viene trasmesso ad Application Insights.
+
+#### Trasferimento dei dati all'estero
+
+Microsoft può elaborare i dati in centri dati al di fuori della Svizzera (UE/USA). Il trasferimento dei dati avviene sulla base delle clausole contrattuali standard ai sensi dell'art. 16 cpv. 2 lett. d LPD e dello Swiss-US Data Privacy Framework. Per ulteriori informazioni, consultare la [politica sulla privacy di Microsoft](https://privacy.microsoft.com/it-it/privacystatement).
+
+
+## 6. Note generali e informazioni obbligatorie
 
 ### Periodo di conservazione
 
@@ -176,6 +257,18 @@ Per l'hosting utilizziamo Cloudflare Pages, un servizio fornito da Cloudflare, I
 
 Base giuridica per il trasferimento dei dati negli Stati Uniti: Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo sulle clausole contrattuali standard della Commissione Europea. Nonostante queste garanzie, non si può escludere completamente un accesso da parte delle autorità statunitensi (ad esempio ai sensi del CLOUD Act).
 
+Nell'ambito delle nostre attività commerciali, i dati personali vengono trasferiti a destinatari nei seguenti paesi:
+
+| Destinatario | Paese | Finalità | Base giuridica |
+|-------------|-------|----------|----------------|
+| Microsoft Corporation (Azure) | UE / USA | Hosting dell'API, database, piattaforma applicativa, monitoraggio | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
+| Sumsub (Sum and Substance Ltd.) | Regno Unito | Verifica dell'identità (KYC) | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
+| Sift Science, Inc. | USA | Prevenzione delle frodi | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
+| Dilisense | UE | Controllo sanzioni e PEP | Decisione di adeguatezza (art. 16 cpv. 1 LPD) |
+| Cloudflare, Inc. | USA | Hosting del sito web e della documentazione (Cloudflare Pages) | Swiss-US DPF / Clausole contrattuali standard (art. 16 cpv. 2 LPD) |
+
+DFX trasferisce dati personali solo verso paesi che dispongono di un livello adeguato di protezione dei dati (ai sensi dell'allegato 1 dell'ordinanza sulla protezione dei dati), o applicando garanzie adeguate come le clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Inoltre, nell'ambito delle transazioni bancarie, i dati dei clienti possono essere trasferiti alle banche partecipanti in Svizzera e all'estero (cfr. Condizioni generali).
+
 ### Crittografia SSL o TLS
 
 Per motivi di sicurezza e per proteggere la trasmissione di contenuti riservati, come le richieste che ci invii in qualità di operatore del sito, questo sito utilizza la crittografia SSL o TLS. Potete riconoscere una connessione crittografata dal fatto che la riga dell'indirizzo del browser cambia da "http://" a "https://" e dal simbolo del lucchetto nella riga del browser.
@@ -199,7 +292,7 @@ I diritti di cui sopra possono essere negati o limitati se prevalgono gli intere
 Ci opponiamo all'utilizzo dei dati di contatto pubblicati nell'ambito dell'obbligo di colophon per l'invio di materiale pubblicitario e informativo non richiesto. Gli operatori delle pagine si riservano espressamente il diritto di intraprendere azioni legali in caso di invio non richiesto di informazioni pubblicitarie, come ad esempio e-mail di spam.
 
 
-## 6. Violazioni della protezione dei dati
+## 7. Violazioni della protezione dei dati
 
 DFX prende molto sul serio le violazioni della protezione dei dati e ha implementato processi per gestire tali incidenti in modo efficiente e in conformità con i requisiti legali. Una violazione della protezione dei dati si verifica quando i dati personali vengono involontariamente o illegalmente divulgati, modificati, cancellati o resi accessibili senza autorizzazione.
 
@@ -215,8 +308,9 @@ In caso di violazione della protezione dei dati, DFX segue una procedura struttu
 
 In caso di violazione della protezione dei dati che rappresenta un rischio per i diritti e le libertà degli interessati, DFX è legalmente obbligata a informare determinate parti. Tali notifiche hanno lo scopo di garantire che sia le autorità competenti che le autorità competentiGli interessati sono informati tempestivamente della violazione e delle misure adottate. Le notifiche vengono effettuate in conformità ai requisiti legali e comprendono le seguenti fasi:
 
-* Notifica all'autorità di controllo entro 72 ore dalla conoscenza della violazione.
-* Notifica agli interessati senza ritardo e in un linguaggio chiaro e comprensibile.
+* Notifica all'autorità di vigilanza competente (IFPDT) il più rapidamente possibile dopo la conoscenza della violazione (art. 24 cpv. 1 LPD).
+* Notifica agli interessati, se ciò è necessario per la loro protezione o se l'IFPDT lo richiede (art. 24 cpv. 4 LPD), senza ritardo e in un linguaggio chiaro e comprensibile.
+* I responsabili del trattamento di DFX (come Sumsub, Sift e altri) sono contrattualmente obbligati a informare DFX immediatamente delle violazioni della protezione dei dati (art. 24 cpv. 3 LPD).
    
 ### Misure di protezione
 
@@ -227,7 +321,7 @@ Per prevenire violazioni della protezione dei dati, utilizziamo misure tecniche 
 Se noti una possibile violazione della protezione dei dati, contatta il nostro [Supporto](https://services.dfx.swiss/support).
 
 
-## 7. Raccolta dati su questo sito
+## 8. Raccolta dati su questo sito
 
 ### Biscotti
 
@@ -240,12 +334,14 @@ Se ci contatti via e-mail, telefono o fax, la tua richiesta, compresi tutti i da
 I dati che ci invii tramite richieste di contatto rimarranno con noi fino a quando non ci chiederai di cancellarli, revocherai il tuo consenso alla memorizzazione o lo scopo della memorizzazione dei dati non sarà più applicabile (ad esempio, dopo che la tua richiesta è stata elaborata). Le disposizioni di legge obbligatorie, in particolare i termini di conservazione previsti dalla legge, rimangono inalterate.
 
 
-##8. Strumenti di analisi e pubblicità
+## 9. Strumenti di analisi e pubblicità
 
 DFX non utilizza strumenti di analisi del sito web come Google Analytics, Adobe Analytics o altri.
 
+Per il monitoraggio operativo lato server dell'infrastruttura API, DFX utilizza Microsoft Azure Application Insights (vedi sezione 5 «Responsabili del trattamento e fornitori terzi»). Questo strumento viene utilizzato esclusivamente per il monitoraggio tecnico, il rilevamento degli errori e l'ottimizzazione delle prestazioni e non raccoglie dati sul comportamento degli utenti sul sito web.
 
-## 9. Newsletter e social media
+
+## 10. Newsletter e social media
 
 ### Dati della newsletter
 
@@ -314,7 +410,7 @@ Il trasferimento dei dati negli USA si basa sulle clausole contrattuali standard
 I dettagli su come gestiscono i tuoi dati personali possono essere trovati nella [Informativa sulla privacy di LinkedIn](https://www.linkedin.com/legal/privacy-policy).
 
 
-## 10. Protezione dei dati durante le candidature e nel processo di candidatura
+## 11. Protezione dei dati durante le candidature e nel processo di candidatura
 
 Il responsabile del trattamento raccoglie e tratta i dati personali dei candidati allo scopo di eseguire il processo di candidatura. Questo trattamento può avvenire anche elettronicamente, in particolare se i candidati inviano la relativa documentazione di candidatura anche via e-mail (ad esempio in formato PDF o altri tipi di file).
 
@@ -327,20 +423,20 @@ Se il responsabile del trattamento stipula un contratto di lavoro con un candida
 Se non viene concluso alcun contratto di lavoro, i documenti di candidatura verranno automaticamente cancellati 12 mesi dopo la notifica della decisione di rifiuto senza ulteriore notifica, a condizione che nessun altro interesse legittimo del centro di elaborazione dati impedisca la cancellazione. Gli interessi legittimi possono essere, ad esempio, l'obbligo di fornire prove in un procedimento ai sensi della legge sulla parità di trattamento (GlG).
 
 
-## 11. Legge applicabile e giurisdizione
+## 12. Legge applicabile e giurisdizione
 
 Il sito web DFX con sede legale in Svizzera è regolato esclusivamente dalla legge svizzera (protezione dei dati), a meno che non sia applicabile un'altra legge obbligatoria alla persona fisica interessata.
 
 Il tribunale della sede legale di DFX (Svizzera) avrà giurisdizione esclusiva per eventuali controversie tra te come visitatore e utente del sito web DFX derivanti dal funzionamento o dalla visita dei siti web, a meno che un altro foro competente obbligatorio non sia applicabile alla persona fisica interessata.
 
 
-## 12. Modifiche all'informativa sulla privacy
+## 13. Modifiche all'informativa sulla privacy
 
 DFX rivede regolarmente la presente informativa sulla privacy per garantire che sia sempre aggiornata e si riserva il diritto di modificarla se necessario. Si consiglia di controllare regolarmente questa pagina per eventuali modifiche, poiché non verrà effettuata alcuna notifica individuale delle modifiche.  
 In caso di discrepanze con la versione inglese, prevarrà la versione tedesca della presente informativa sulla privacy.
 
 
-## 13. Informazioni legali e disclaimer
+## 14. Informazioni legali e disclaimer
 
 DFX non si assume alcuna responsabilità per l'accuratezza e la completezza del contenuto delle informazioni.
 
@@ -349,19 +445,19 @@ Sono sostanzialmente escluse pretese di responsabilità per danni materiali o im
 Tutte le offerte pubblicate da DFX in formato digitale o elettronico sono soggette a modifiche. DFX si riserva espressamente il diritto di modificare, integrare o eliminare parti delle pagine o l'intera offerta senza preavviso o di cessare la pubblicazione temporaneamente o permanentemente.
 
 
-## 14. Responsabilità per i collegamenti
+## 15. Responsabilità per i collegamenti
 
 Riferimenti e collegamenti a siti Web di terzi non rientrano nella responsabilità di DFX. Si declina qualsiasi responsabilità per siti web di terzi, cioè al di fuori delle società appartenenti a DFX. L'accesso e l'utilizzo di tali siti web sono a rischio e pericolo dell'utente.
 
 Tutte le offerte pubblicate da DFX in formato digitale o elettronico sono soggette a modifiche. DFX si riserva espressamente il diritto di modificare, integrare o eliminare parti delle pagine o l'intera offerta senza preavviso o di cessare la pubblicazione.attivo temporaneamente o permanentemente.
 
 
-##15. Diritto d'autore e proprietà intellettuale 
+## 16. Diritto d'autore e proprietà intellettuale 
 
 Il copyright e tutti gli altri diritti su contenuti, immagini, foto o altri file sul sito web DFX appartengono esclusivamente a DFX e alle sue società affiliate, ai loro fornitori o ai titolari dei diritti specificatamente nominati.
 
 
-##16. Consenso alla privacy policy
+## 17. Consenso alla privacy policy
 
 Il cliente accetta integralmente il contenuto dell'informativa sulla privacy nella sua versione attuale. In caso di contraddizioni, la politica sulla privacy ha la precedenza sui Termini e condizioni generali di DFX.
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -180,7 +180,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting delle pagine statiche senza dati dei clienti e accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
+I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting delle pagine statiche senza dati dei clienti e accesso ai servizi), a Sumsub (Regno Unito) e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
 
 ### Crittografia SSL o TLS
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -122,9 +122,9 @@ Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere info
 
 ## 4. Hosting e infrastruttura
 
-DFX ospita i siti web statici senza dati dei clienti (ad esempio dfx.swiss) presso Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA).
+DFX ospita le pagine informative statiche che non raccolgono dati dei clienti (ad esempio dfx.swiss) presso Cloudflare (Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA). Su queste pagine non ci sono conti clienti, transazioni né verifica dell'identità.
 
-DFX gestisce l'API, la piattaforma applicativa e il database su server propri in Svizzera. L'accesso pubblico a questi servizi avviene tramite Cloudflare come content delivery network e reverse proxy.
+Tutto ciò che tratta dati dei clienti — l'API, la piattaforma applicativa e il database — è gestito da DFX su server propri in Svizzera. L'accesso pubblico a questi servizi avviene tramite Cloudflare come content delivery network e reverse proxy.
 
 All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i metadati della richiesta) vengono trasmessi a Cloudflare. Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo su clausole contrattuali standard (art. 16 cpv. 2 lett. d LPD). Dettagli: [informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/) e [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
@@ -180,7 +180,7 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting dei siti statici e accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
+I dati personali sono trattati in Svizzera. Al di fuori della Svizzera sono trasmessi a Cloudflare (USA, hosting delle pagine statiche senza dati dei clienti e accesso ai servizi), ai responsabili del trattamento indicati sopra e, nell'ambito delle transazioni bancarie, alle banche partecipanti (cfr. Condizioni generali).
 
 ### Crittografia SSL o TLS
 

--- a/src/it/tnc.md
+++ b/src/it/tnc.md
@@ -79,9 +79,9 @@ Per le transazioni blockchain da DFX a portafogli non self-hosted, questi dati v
 
 Prima di poter utilizzare i servizi finanziari di DFX, il cliente deve registrarsi tramite l'app DFX o la pagina di pagamento. La registrazione è gratuita e porta alla creazione di un profilo utente dopo l'accettazione dei termini e delle condizioni vigenti. Inoltre, viene creato un portafoglio non di deposito. DFX non ha accesso a questo portafoglio, ma solo al cliente. Quando un cliente si registra, le informazioni e i documenti che deve presentare a DFX e l'importo massimo per il quale può acquistare o vendere criptovalute dipendono dal suo livello di identificazione:
 
-In linea di massima, la registrazione avviene tramite l'indirizzo della blockchain, specificando l'e-mail o il numero di telefono del cliente. Questa registrazione è considerata standard - light KYC (Know-your-Customer) - e consente al cliente di acquistare/vendere criptovalute fino al limite giornaliero stabilito, visibile sulla pagina di pagamento personale del cliente. I trasferimenti di criptovalute a un indirizzo pubblico non verificato non sono accettati.
+In linea di massima, la registrazione avviene tramite l'indirizzo della blockchain, specificando l'e-mail o il numero di telefono del cliente. Questa registrazione è considerata standard - light KYC (Know-your-Customer) - e consente al cliente di acquistare/vendere criptovalute fino al limite mensile stabilito (periodo mobile di 30 giorni), visibile sulla pagina di pagamento personale del cliente. I trasferimenti di criptovalute a un indirizzo pubblico non verificato non sono accettati.
 
-Per l'acquisto/vendita di criptovalute al di sopra di questo limite giornaliero, è richiesta una registrazione più dettagliata, che è considerata un processo esteso - KYC (Know-your-Customer) completo. Nell'ambito di questo processo, devono essere comunicate a DFX in particolare le seguenti informazioni:
+Per l'acquisto/vendita di criptovalute al di sopra di questo limite mensile, è richiesta una registrazione più dettagliata, che è considerata un processo esteso - KYC (Know-your-Customer) completo. Nell'ambito di questo processo, devono essere comunicate a DFX in particolare le seguenti informazioni:
 
 - Indirizzo, con la prova della consegna di una lettera all'indirizzo indicato.
 - Copia del documento d'identità (carta d'identità o passaporto), che deve recare una firma, un codice MRZ leggibile e una fotografia.
@@ -164,7 +164,7 @@ I percorsi di vendita possono essere annullati finché la criptovaluta da conver
 
 I costi di transazione delle [criptovalute o] valute estere trasmesse al cliente sono inclusi nel prezzo base. I prezzi sono espressi nella criptovaluta consentita per la transazione e includono l'imposta sul valore aggiunto svizzera (di seguito: IVA), se applicabile. Dopo il trasferimento della [criptovaluta o] della valuta estera desiderata sul conto[/portafoglio] del cliente, la vendita si considera conclusa. Il cliente riceverà un'e-mail di conferma del completamento della transazione e una panoramica della stessa.
 
-DFX sottolinea che esiste un volume massimo di vendite per giorno e per cliente, che può essere visualizzato dal cliente sulla pagina payemn. Il cliente ha la possibilità di richiedere un volume di vendite superiore. Tale richiesta sarà valutata e discussa individualmente da DFX. 
+DFX sottolinea che esiste un volume massimo di vendite per mese (periodo mobile di 30 giorni) e per cliente, che può essere visualizzato dal cliente sulla pagina payemn. Il cliente ha la possibilità di richiedere un volume di vendite superiore. Tale richiesta sarà valutata e discussa individualmente da DFX. 
 
 Gli storni delle vendite ai clienti di DFX AG vengono effettuati esclusivamente nella criptovaluta che è stata trasferita a DFX per la vendita. L'importo del riaddebito corrisponde esattamente all'importo trasferito a DFX per la vendita.
 

--- a/src/it/tnc.md
+++ b/src/it/tnc.md
@@ -213,7 +213,7 @@ Le rotte di vendita possono essere annullate finché la criptovaluta da converti
 
 I costi di transazione delle criptovalute o delle valute estere trasmesse al cliente sono inclusi nel prezzo base. I prezzi sono indicati nella criptovaluta consentita per la transazione e includono l'IVA svizzera, se applicabile. Una volta effettuato il trasferimento della criptovaluta desiderata o della valuta estera desiderata sul portafoglio/conto del cliente, la vendita è considerata completata. Il cliente riceve un'e-mail di conferma del completamento della transazione con una panoramica della transazione.
 
-DFX sottolinea che esiste un volume massimo di vendite al mese (periodo mobile di 30 giorni) e per cliente. Il cliente ha la possibilità di richiedere un volume di vendita maggiore. Questa richiesta sarà valutata e discussa individualmente da DFX. 
+DFX sottolinea che esiste un volume massimo di vendite al mese (periodo mobile di 30 giorni) e per cliente. Il cliente ha la possibilità di richiedere un volume di vendita maggiore. Questa richiesta sarà valutata e discussa individualmente da DFX.
 
 I rimborsi delle vendite ai clienti DFX vengono effettuati esclusivamente nella criptovaluta originariamente trasferita. L'importo rimborsato corrisponde esattamente al valore trasferito a DFX per la vendita.
 
@@ -262,5 +262,5 @@ DFX offre il pagamento utilizzando i seguenti standard:
 Le tariffe per l'attività di recupero crediti sono fissate come segue:
 * DFX generalmente non addebita alcuna commissione per la liquidazione delle richieste di recupero crediti.
 *DFX definisce un indirizzo blockchain al quale può essere trasmesso l'importo richiesto. Per i pagamenti tramite Lightning, viene creata una fattura BOLT11. I costi per le commissioni blockchain o le commissioni di routing Lightning sono a carico dell'utente e non fanno parte del servizio di recupero crediti di DFX. Queste commissioni sono variabili.
-* Se l'utente decide di pagare in una valuta estera, DFX addebita una commissione di conversione valutaria dell'1% se come metodo di pagamento viene selezionato FrankencoinPay, Lightning BOLT11 o OpenCryptoPay.io.  
+* Se l'utente decide di pagare in una valuta estera, DFX addebita una commissione di conversione valutaria dell'1% se come metodo di pagamento viene selezionato Lightning BOLT11 o OpenCryptoPay.io.
 Per tutte le altre opzioni di pagamento, come "PayToBlockchainAddress", viene addebitata una commissione di conversione valutaria del 2%. La tariffa maggiorata è necessaria perché questi metodi di pagamento offrono un periodo di validità più lungo.

--- a/src/it/tnc.md
+++ b/src/it/tnc.md
@@ -142,9 +142,9 @@ Per le transazioni blockchain da DFX a portafogli non self-hosted, questi dati v
 ## Registrazione utente
 Prima di poter utilizzare i servizi finanziari di DFX, il cliente deve registrarsi. Per i privati ​​la registrazione è gratuita e, previa accettazione dei presenti Termini e Condizioni, porta alla creazione di un profilo utente. Quando un cliente si registra, le informazioni e i documenti che il cliente deve inviare a DFX e l'importo massimo per il quale il cliente può acquistare o vendere criptovalute dipendono dal suo livello di identificazione:
 
-La registrazione viene generalmente effettuata tramite l'indirizzo blockchain, fornendo l'e-mail o il numero di telefono del cliente. Questa registrazione è considerata standard – light KYC (Know-Your-Customer) – e consente al cliente di acquistare/vendere criptovalute fino a un limite giornaliero definito. 
+La registrazione viene generalmente effettuata tramite l'indirizzo blockchain, fornendo l'e-mail o il numero di telefono del cliente. Questa registrazione è considerata standard – light KYC (Know-Your-Customer) – e consente al cliente di acquistare/vendere criptovalute fino a un limite mensile definito (periodo mobile di 30 giorni).
 
-Per l'acquisto/vendita di criptovalute superiori a thPoiché esiste un limite giornaliero, è necessaria una registrazione più dettagliata, che è considerata un processo KYC (Know-Your-Customer) esteso e completo. Nell'ambito di questo processo, le seguenti informazioni in particolare devono essere divulgate a DFX:
+Per l'acquisto/vendita di criptovalute al di sopra di questo limite mensile, è necessaria una registrazione più dettagliata, che è considerata un processo KYC (Know-Your-Customer) esteso e completo. Nell'ambito di questo processo, le seguenti informazioni in particolare devono essere divulgate a DFX:
 
 * Indirizzo, la cui prova è fornita mediante consegna di una lettera all'indirizzo specificato
 * Copia del documento di riconoscimento (carta d'identità o passaporto), che deve riportare una firma, un codice MRZ leggibile e una foto
@@ -213,7 +213,7 @@ Le rotte di vendita possono essere annullate finché la criptovaluta da converti
 
 I costi di transazione delle criptovalute o delle valute estere trasmesse al cliente sono inclusi nel prezzo base. I prezzi sono indicati nella criptovaluta consentita per la transazione e includono l'IVA svizzera, se applicabile. Una volta effettuato il trasferimento della criptovaluta desiderata o della valuta estera desiderata sul portafoglio/conto del cliente, la vendita è considerata completata. Il cliente riceve un'e-mail di conferma del completamento della transazione con una panoramica della transazione.
 
-DFX sottolinea che esiste un volume massimo di vendite al giorno e per cliente. Il cliente ha la possibilità di richiedere un volume di vendita maggiore. Questa richiesta sarà valutata e discussa individualmente da DFX. 
+DFX sottolinea che esiste un volume massimo di vendite al mese (periodo mobile di 30 giorni) e per cliente. Il cliente ha la possibilità di richiedere un volume di vendita maggiore. Questa richiesta sarà valutata e discussa individualmente da DFX. 
 
 I rimborsi delle vendite ai clienti DFX vengono effettuati esclusivamente nella criptovaluta originariamente trasferita. L'importo rimborsato corrisponde esattamente al valore trasferito a DFX per la vendita.
 
@@ -237,7 +237,7 @@ Si applicano le seguenti disposizioni:
   *Le manipolazioni tecniche per ingannare DFX riguardo al pagamento non sono consentite e verranno segnalate. In particolare, la “doppia spesa” non è consentita e sarà perseguita come frode.
 
 DFX offre il pagamento utilizzando i seguenti standard:
-* FrankencoinPay e OpenCryptoPay
+* OpenCryptoPay
   * Pagamenti tramite Lightning BOLT11
     * L'utente sostiene la tariffa di instradamento.
     * Un contributo ricevuto, ad esempio, di 1 BTC corrisponde a 1 BTC.

--- a/src/it/tnc.md
+++ b/src/it/tnc.md
@@ -14,7 +14,7 @@ Accedendo e utilizzando il sito web e scaricando informazioni, dati e documenti 
 
 ## Nessun consiglio
 DFX non fornisce consulenza in materia di investimenti, fiscale o legale. Le informazioni fornite sul sito web sono solo a scopo informativo e non costituiscono raccomandazioni. I clienti prendono le loro decisioni di investimento in modo indipendente e si assumono la piena responsabilità dei rischi che ne derivano.  
-Ciò vale per tutti i servizi finanziari offerti da DFX, che includono l'acquisto, la vendita, lo scambio e l'invio di criptovalute.  
+Ciò vale per tutti i servizi finanziari offerti da DFX, che includono l'acquisto, la vendita e lo scambio di criptovalute.  
 
 Tutte le decisioni di investimento prese dai clienti si basano esclusivamente sulla valutazione della propria situazione finanziaria e degli obiettivi di investimento. Sono gli unici responsabili di tali decisioni e delle conseguenze che ne derivano. DFX fornisce i propri servizi esclusivamente su richiesta esplicita e indipendente del cliente, senza verificare la sua situazione finanziaria, la comprensione tecnica, l'idoneità o l'adeguatezza dell'investimento.
 
@@ -65,7 +65,6 @@ I servizi finanziari di DFX includono:
 * Acquista
 *Vendi
 * Scambia (Scambia)
-* Invia
 
 Le opzioni di pagamento includono:
 * Bonifico bancario
@@ -94,17 +93,6 @@ Si prega di astenersi dal contattare direttamente la banca, poiché ciò comport
 ## Restrizioni locali
 
 I prodotti e i servizi offerti su questo sito web sono approvati per la vendita solo in Svizzera. Chi accede al sito dall'estero lo fa a proprio rischio. DFX declina ogni responsabilità in relazione all'utilizzo del sito web al di fuori della Svizzera. In particolare, si sottolinea che ogni utente straniero è obbligato a chiarire da solo se può utilizzare i servizi e i prodotti offerti da DFX in base alla legislazione applicabile nel proprio luogo di residenza o sede legale, o in base alla legislazione del proprio paese d'origine.
-
-## Custodia dei beni
-### Termini di custodia
-DFX offre la custodia dei beni per i clienti. Sono idonee a ciò le seguenti classi di attività: franchi svizzeri (CHF), euro (EUR), Bitcoin (BTC) e Frankencoin Pool Shares (FPS). La custodia di tali beni è soggetta alle seguenti condizioni:
-* Flessibilità nella scelta dell'asset in custodia: se un cliente decide di custodire un determinato importo di una classe di asset con DFX, è a discrezione di DFX decidere in quale tipo o su quale blockchain è detenuto questo asset.
-    * Esempio 1: se il cliente decide di custodire BTC, DFX può conservarlo sulla catena principale di Bitcoin o come Wrapped Bitcoin (WBTC) sulla blockchain di Ethereum.
-    * Esempio 2: se il cliente sceglie FPS, questo può essere mantenuto come FPS su Ethereum o come WFPS (Wrapped FPS) su Polygon.  
-
-DFX si riserva questa flessibilità per rendere la custodia efficiente e sicura. Tutte le attività detenute per i clienti sono tenute segregate a un indirizzo specifico del cliente. I clienti hanno la possibilità di visualizzare in qualsiasi momento tramite la [soluzione software DFX](https://app.dfx.swiss/) che indirizza la loro risorsavengono conservati e in quale tipo (asset e blockchain).
-
-La custodia viene effettuata nel rispetto delle normative svizzere applicabili, in particolare per quanto riguarda la sicurezza e la protezione dei fondi dei clienti. DFX garantisce che le attività detenute non siano mescolate con le proprie attività. I beni detenuti sono sempre di proprietà del cliente e non rientrerebbero nella massa fallimentare in caso di insolvenza.
 
 ## Gestione dei dati delle transazioni
 Per tutte le transazioni di risorse digitali, le seguenti informazioni sono rese pubbliche:
@@ -140,11 +128,7 @@ Sono richieste almeno le seguenti informazioni:
 Per le transazioni blockchain da DFX a portafogli non self-hosted, questi dati vengono automaticamente trasmessi da DFX al provider di hosting. Salvo diverso accordo, i dati vengono trasmessi via e-mail a compliance(at)"provider.domain". Si consiglia ai clienti di DFX che non desiderano accettare questa trasmissione di utilizzare un portafoglio ospitato autonomamente.
 
 ## Registrazione utente
-Prima di poter utilizzare i servizi finanziari di DFX, il cliente deve registrarsi. Per i privati ​​la registrazione è gratuita e, previa accettazione dei presenti Termini e Condizioni, porta alla creazione di un profilo utente. Quando un cliente si registra, le informazioni e i documenti che il cliente deve inviare a DFX e l'importo massimo per il quale il cliente può acquistare o vendere criptovalute dipendono dal suo livello di identificazione:
-
-La registrazione viene generalmente effettuata tramite l'indirizzo blockchain, fornendo l'e-mail o il numero di telefono del cliente. Questa registrazione è considerata standard – light KYC (Know-Your-Customer) – e consente al cliente di acquistare/vendere criptovalute fino a un limite mensile definito (periodo mobile di 30 giorni).
-
-Per l'acquisto/vendita di criptovalute al di sopra di questo limite mensile, è necessaria una registrazione più dettagliata, che è considerata un processo KYC (Know-Your-Customer) esteso e completo. Nell'ambito di questo processo, le seguenti informazioni in particolare devono essere divulgate a DFX:
+Prima di poter utilizzare i servizi finanziari di DFX, il cliente deve registrarsi e completare la verifica dell'identità (KYC). Per i privati la registrazione è gratuita e, previa accettazione dei presenti Termini e Condizioni, porta alla creazione di un profilo utente. Acquisto, vendita e scambio sono possibili solo dopo il completamento della verifica dell'identità. Nell'ambito della verifica dell'identità, le seguenti informazioni in particolare devono essere divulgate a DFX:
 
 * Indirizzo, la cui prova è fornita mediante consegna di una lettera all'indirizzo specificato
 * Copia del documento di riconoscimento (carta d'identità o passaporto), che deve riportare una firma, un codice MRZ leggibile e una foto
@@ -158,9 +142,9 @@ I limiti fino ai quali vengono eseguiti gli acquisti/vendite di criptovalute son
 
 DFX si riserva il diritto di condurre una videoconferenza per verificare l'identità del cliente. Ciò si applica, tra l'altro, se DFX ritiene che i documenti forniti siano incompleti, che il luogo di residenza o l'attività del cliente si trovi in ​​un paese a rischio o che la prima transazione effettuata dal cliente sia stata effettuata da un paese a rischio o tramite un conto bancario che non è a nome del cliente.
 
-L'invio e la convalida completi e corretti di questi documenti sono richiesti per il primo acquisto e vendita di criptovalute, nonché per la conversione di criptovalute, o in qualsiasi momento su richiesta di DFX senza fornire motivazioni.
+L'invio e la convalida completi e corretti di questi documenti sono richiesti per l'acquisto, la vendita e lo scambio di criptovalute.
 
-I dati forniti devono essere sempre completi e validi. Le modifiche ai dati personali e tutti i dati alla base del KYC light o full devono essere comunicate a DFX dal cliente senza indugio.
+I dati forniti devono essere sempre completi e validi. Le modifiche ai dati personali e tutti i dati alla base del KYC devono essere comunicate a DFX dal cliente senza indugio.
 
 I dipendenti DFX non chiedono mai al cliente password, chiavi private o seed. Tali richieste dovrebbero essere ignorate e segnalate a DFX.
 
@@ -216,51 +200,3 @@ I costi di transazione delle criptovalute o delle valute estere trasmesse al cli
 DFX sottolinea che esiste un volume massimo di vendite al mese (periodo mobile di 30 giorni) e per cliente. Il cliente ha la possibilità di richiedere un volume di vendita maggiore. Questa richiesta sarà valutata e discussa individualmente da DFX.
 
 I rimborsi delle vendite ai clienti DFX vengono effettuati esclusivamente nella criptovaluta originariamente trasferita. L'importo rimborsato corrisponde esattamente al valore trasferito a DFX per la vendita.
-
-## Programma di riferimento
-Il nostro programma di riferimento paga ai clienti lo 0,25% sul volume di acquisto/investimento acquistato da un nuovo cliente tramite il link di riferimento del cliente, nonché lo 0,1% sulle transazioni del collegamento di pagamento. 
-
-Si sottolinea che la partecipazione al programma di riferimento è consentita solo ai clienti DFX. Si precisa inoltre che il programma di riferimento può essere interrotto o modificato in qualsiasi momento e senza preavviso. Ulteriori dettagli possono essere visualizzati su https://app.dfx.swiss/account. Si precisa che questo collegamento funziona solo se l'utente ha già effettuato l'accesso con il proprio account cliente.
-
-Il programma di referral si rivolge a clienti residenti in Svizzera ed è destinato a referral in ambito personale. Non stabilisce alcun rapporto di rappresentanza, mediazione o mandato. Il cliente non è autorizzato ad agire per conto di DFX o a fare dichiarazioni. Non è consentita la pubblicità pubblica o a pagamento/sponsorizzata o la distribuzione del codice di riferimento o dei servizi DFX (ad esempio tramite siti Web o social media). Il cliente riconosce che la trasmissione o la pubblicità al di fuori della Svizzera può violare le normative locali. In caso di sospetto o prova di una violazione, DFX può bloccare la partecipazione e rifiutare o reclamare benefici o compensi. Il cliente risarcirà DFX per i danni derivanti dalla violazione colposa di questa disposizione, comprese le ragionevoli spese legali. Il cliente risarcisce multe o sanzioni ufficiali solo nella misura in cui ciò è consentito dalla legge e sono state causate direttamente dal suo comportamento colpevole.
-
-## Attività di recupero crediti
-
-## Ambito e pagdisposizioni relative all’attività di recupero crediti
-L'attività di recupero crediti di DFX comprende:
-*Link per il pagamento
-
-Si applicano le seguenti disposizioni: 
-*Le parti contraenti che desiderano cedere crediti a DFX attraverso l'attività di recupero crediti devono concordare ciò mediante un contratto separato con DFX. Se non diversamente previsto nel contratto, si applicano commissioni pari allo 0,1% sul fatturato.
-* Gli utenti che decidono di liquidare un credito in sospeso tramite il servizio di recupero crediti DFX possono farlo alle seguenti condizioni:
-  * Ogni richiesta ha un periodo di validità definito, specificato in UTC. Il pagamento deve essere effettuato entro questo termine.
-  *Le manipolazioni tecniche per ingannare DFX riguardo al pagamento non sono consentite e verranno segnalate. In particolare, la “doppia spesa” non è consentita e sarà perseguita come frode.
-
-DFX offre il pagamento utilizzando i seguenti standard:
-* OpenCryptoPay
-  * Pagamenti tramite Lightning BOLT11
-    * L'utente sostiene la tariffa di instradamento.
-    * Un contributo ricevuto, ad esempio, di 1 BTC corrisponde a 1 BTC.
-  * Pagamenti su una blockchain basata su EVM
-    *L'utente sostiene la commissione blockchain.
-    * Un contributo ricevuto ad esempio di 1 ZCHF corrisponde a 1 ZCHF.
-  * Pagamenti su una blockchain basata su UTXO
-    *L'utente sostiene la commissione blockchain.
-    * Un contributo ricevuto, ad esempio, di 1 BTC non corrisponde a 1 BTC.
-      * I costi per la ricezione di un UTXO vengono addebitati inoltre al mittente, poiché DFX può spendere l'UTXO ricevuto solo se viene pagata la commissione di transazione blockchain corrispondente.
-      * DFX considera quindi l'importo tecnicamente ricevuto meno l'attuale commissione sulla transazione blockchain come l'importo effettivamente ricevuto.
-
-* Pagamenti tramite Lightning BOLT11
-    *analogo al precedente
-
-* Indirizzo PayToBlockchain
-  * Pagamenti su una blockchain basata su EVM
-    *analogo al precedente
-  * Pagamenti su una blockchain basata su UTXO
-    *analogo al precedente
-
-Le tariffe per l'attività di recupero crediti sono fissate come segue:
-* DFX generalmente non addebita alcuna commissione per la liquidazione delle richieste di recupero crediti.
-*DFX definisce un indirizzo blockchain al quale può essere trasmesso l'importo richiesto. Per i pagamenti tramite Lightning, viene creata una fattura BOLT11. I costi per le commissioni blockchain o le commissioni di routing Lightning sono a carico dell'utente e non fanno parte del servizio di recupero crediti di DFX. Queste commissioni sono variabili.
-* Se l'utente decide di pagare in una valuta estera, DFX addebita una commissione di conversione valutaria dell'1% se come metodo di pagamento viene selezionato Lightning BOLT11 o OpenCryptoPay.io.
-Per tutte le altre opzioni di pagamento, come "PayToBlockchainAddress", viene addebitata una commissione di conversione valutaria del 2%. La tariffa maggiorata è necessaria perché questi metodi di pagamento offrono un periodo di validità più lungo.


### PR DESCRIPTION
EN:
The privacy policy now states that DFX hosts static pages without customer data on Cloudflare and runs API, app and database on its own servers in Switzerland.
The terms now offer only buy, sell and crypto-to-crypto trading after KYC.
Send, custody, referral and collection are removed.

DE:
Die Datenschutzerklärung hält fest, dass DFX statische Seiten ohne Kundendaten bei Cloudflare hostet und API, App und Datenbank auf eigenen Servern in der Schweiz betreibt.
Die AGB bieten nur noch Kauf, Verkauf und Crypto-zu-Crypto nach KYC.
Send, Verwahrung, Referral und Inkasso sind entfernt.

<details>
<summary>Details</summary>

Privacy (DE/EN/FR/IT):
- Static information pages without customer data hosted on Cloudflare
- Own servers in Switzerland for API, app and database
- Processors: Sumsub (UK), Dilisense (Switzerland)

Terms (DE/EN/FR/IT):
- Services: Buy, Sell, Swap only, after KYC
- Removed: Send, custody, referral, payment-link/collection, light KYC

</details>