### PR TITLE
feat(deploy): migrate prd to Cloudflare Pages

### DIFF
--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -1,38 +1,50 @@
-name: Deploy to All-Inkl
+name: Deploy main to Cloudflare Pages
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: prd-deploy
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '16.x'
 
 jobs:
-  build-and-deploy:
-    name: Build, and deploy to All-Inkl
+  deploy:
+    name: Build + wrangler pages deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install packages
-        run: |
-          npm ci
+        run: npm ci
 
-      - name: Build code
-        run: |
-          npm run build
+      - name: Build
+        run: npm run build
 
-      - name: Deploy to All-Inkl
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-        with:
-          server: ${{ secrets.PRD_HOST }}
-          username: ${{ secrets.PRD_USER }}
-          password: ${{ secrets.PRD_PASSWORD }}
-          local-dir: './src/.vuepress/dist/'
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler pages deploy ./src/.vuepress/dist \
+            --project-name=dfx-docs-prd \
+            --branch=main \
+            --commit-hash=${{ github.sha }} \
+            --commit-message="${{ github.event.head_commit.message }}"


### PR DESCRIPTION
Replace FTP-Deploy-Action targeting All-Inkl with wrangler-based Direct Upload to Cloudflare Pages.

Pattern: same as DFXswiss/landing-page#120 (merged 2026-05-26 after All-Inkl shared-hosting outage on 85.13.138.57).

Paired with a Terraform change in DFXServer/server that creates the matching Pages project and switches the DNS record from `A 85.13.138.57` to a CNAME on the corresponding `*.pages.dev` host. Order of operations:

1. Server PR merged → TF apply creates Pages project + DNS switch.
2. This PR merged → push to `main` → wrangler deploys content to the Pages project.

All-Inkl FTP secrets (`PRD_HOST`/`PRD_USER`/`PRD_PASSWORD`) stay for now and can be removed once the cutover is validated.

DEV deploy (`dev.yaml`) unchanged — stays on FTP for now.