### PR TITLE
privacy: update hosting provider to Cloudflare Pages

### DIFF
--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -122,11 +122,11 @@ Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sow
 
 ## 4. Hosting
 
-### Hosting mit All-Inkl
+### Hosting mit Cloudflare Pages
 
-Wir hosten unsere Website bei All-Inkl. Anbieter ist ALL-INKL.COM - Neue Medien Münnich, Inh. René Münnich, Hauptstrasse 68, 02742 Friedersdorf (im Folgenden: All-Inkl). 
+Wir hosten unsere Website bei Cloudflare Pages. Anbieter ist Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (im Folgenden: Cloudflare).
 
-All-Inkl hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in den [Datenschutzbestimmungen von All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+Cloudflare hat geeignete technische und organisatorische Massnahmen implementiert, um den Schutz personenbezogener Daten zu gewährleisten. Einzelheiten zu deren Umgang mit personenbezogenen Daten finden Sie in der [Datenschutzerklärung von Cloudflare](https://www.cloudflare.com/privacypolicy/). Die Verarbeitung in unserem Auftrag erfolgt auf Grundlage des [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Allgemeine Hinweise und Pflicht­informationen
@@ -172,7 +172,9 @@ Die Website speichert und verarbeitet lediglich die Daten welche als Minimum not
 
 ### Hinweis zur Datenweitergabe ins Ausland
 
-Wir verwenden für das Hosting namens All-Inkl, ein Unternehmen aus Deutschland. Wenn diese Tools aufgerufen werden, werden Ihre personenbezogene Daten in diesen Drittstaat übertragen und könnten dort verarbeitet werden.
+Wir nutzen für das Hosting Cloudflare Pages, einen Dienst der Cloudflare, Inc. mit Sitz in den USA. Beim Aufruf unserer Website werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowie Request-Metadaten) in die USA übertragen und dort verarbeitet, da Cloudflare als Reverse Proxy / Content Delivery Network die Verbindungen terminiert.
+
+Rechtsgrundlage der Datenübermittlung in die USA: Cloudflare ist nach dem [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) und nach dem Swiss-U.S. Data Privacy Framework zertifiziert. Ergänzend stützen wir die Übermittlung auf die Standardvertragsklauseln der EU-Kommission. Wir weisen darauf hin, dass trotz dieser Schutzmechanismen ein Zugriff durch US-Behörden (z. B. nach dem CLOUD Act) nicht vollständig ausgeschlossen werden kann.
 
 ### SSL- bzw. TLS-Verschlüsselung
 

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -122,11 +122,11 @@ Data subjects have the right to object to profiling and to request information a
 
 ## 4. Hosting
 
-### Hosting with All-Inkl
+### Hosting with Cloudflare Pages
 
-We host our website with All-Inkl. The provider is ALL-INKL.COM - Neue Medien Münnich, owner René Münnich, Hauptstrasse 68, 02742 Friedersdorf (hereinafter: All-Inkl). 
+We host our website with Cloudflare Pages. The provider is Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (hereinafter: Cloudflare).
 
-All-Inkl has implemented appropriate technical and organizational measures to ensure the protection of personal data. Details on their handling of personal data can be found in the [privacy policy of All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+Cloudflare has implemented appropriate technical and organizational measures to ensure the protection of personal data. Details on their handling of personal data can be found in the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). Processing on our behalf is governed by the [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. General notes and mandatory information
@@ -172,7 +172,9 @@ The website only stores and processes the minimum data necessary to operate the 
 
 ### Note on data transfer abroad
 
-We use the hosting service All-Inkl, a company from Germany. When these tools are accessed, your personal data is transferred to this third country and could be processed there.
+For hosting we use Cloudflare Pages, a service provided by Cloudflare, Inc. based in the USA. When you access our website, technically necessary data (in particular your IP address and request metadata) is transferred to the USA and processed there, as Cloudflare terminates the connection as a reverse proxy / content delivery network.
+
+Legal basis for the data transfer to the USA: Cloudflare is certified under the [EU-U.S. Data Privacy Framework](https://www.dataprivacyframework.gov/) and under the Swiss-U.S. Data Privacy Framework. In addition, we rely on the EU Commission's Standard Contractual Clauses. Despite these safeguards, access by U.S. authorities (e.g., under the CLOUD Act) cannot be entirely excluded.
 
 ### SSL or TLS encryption
 

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -122,11 +122,11 @@ Les personnes concernées ont le droit de s'opposer au profilage et de demander 
 
 ## 4. Hébergement
 
-### Hébergement avec All-Inkl
+### Hébergement avec Cloudflare Pages
 
-Nous hébergeons notre site Web avec All-Inkl. Le fournisseur est ALL-INKL.COM - Neue Medien Münnich, propriétaire René Münnich, Hauptstrasse 68, 02742 Friedersdorf (ci-après : All-Inkl).
+Nous hébergeons notre site Web avec Cloudflare Pages. Le fournisseur est Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (ci-après : Cloudflare).
 
-All-Inkl a mis en œuvre des mesures techniques et organisationnelles appropriées pour assurer la protection des données personnelles. Des détails sur leur traitement des données personnelles peuvent être trouvés dans la [politique de confidentialité d'All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+Cloudflare a mis en œuvre des mesures techniques et organisationnelles appropriées pour assurer la protection des données personnelles. Des détails sur leur traitement des données personnelles peuvent être trouvés dans la [politique de confidentialité de Cloudflare](https://www.cloudflare.com/privacypolicy/). Le traitement pour notre compte est régi par le [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ## 5. Notes générales et informations obligatoires
@@ -172,7 +172,9 @@ Le site Web stocke et traite uniquement les données minimales nécessaires au f
 
 ### Remarque sur le transfert de données à l'étranger
 
-Nous utilisons le service d'hébergement All-Inkl, une société allemande. Lors de l’accès à ces outils, vos données personnelles sont transférées vers ce pays tiers et pourraient y être traitées.
+Pour l'hébergement, nous utilisons Cloudflare Pages, un service fourni par Cloudflare, Inc., basée aux États-Unis. Lorsque vous accédez à notre site Web, des données techniquement nécessaires (notamment votre adresse IP et les métadonnées de requête) sont transférées aux États-Unis et y sont traitées, car Cloudflare termine la connexion en tant que reverse proxy / réseau de diffusion de contenu (CDN).
+
+Base juridique du transfert de données vers les États-Unis : Cloudflare est certifié au titre du [Data Privacy Framework UE–États-Unis](https://www.dataprivacyframework.gov/) et du Data Privacy Framework Suisse–États-Unis. Nous nous appuyons en outre sur les clauses contractuelles types de la Commission européenne. Malgré ces garanties, un accès des autorités américaines (par exemple en vertu du CLOUD Act) ne peut être entièrement exclu.
 
 ### Cryptage SSL ou TLS
 

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -122,11 +122,11 @@ Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere info
 
 ## 4. Ospitalità
 
-### Hosting con All-Inkl
+### Hosting con Cloudflare Pages
 
-Ospitiamo il nostro sito Web con All-Inkl. Il fornitore è ALL-INKL.COM - Neue Medien Münnich, proprietario René Münnich, Hauptstrasse 68, 02742 Friedersdorf (di seguito: All-Inkl). 
+Ospitiamo il nostro sito Web con Cloudflare Pages. Il fornitore è Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, USA (di seguito: Cloudflare).
 
-All-Inkl ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. I dettagli sul trattamento dei dati personali sono disponibili nell'[informativa sulla privacy di All-Inkl](https://all-inkl.com/datenschutzinformationen/).
+Cloudflare ha implementato misure tecniche e organizzative adeguate per garantire la protezione dei dati personali. I dettagli sul trattamento dei dati personali sono disponibili nell'[informativa sulla privacy di Cloudflare](https://www.cloudflare.com/privacypolicy/). Il trattamento per nostro conto si basa sul [Cloudflare Data Processing Addendum](https://www.cloudflare.com/cloudflare-customer-dpa/).
 
 
 ##5. Note generali e informazioni obbligatorie
@@ -172,7 +172,9 @@ Il sito web memorizza ed elabora solo i dati minimi necessari per il funzionamen
 
 ### Nota sul trasferimento dati all'estero
 
-Utilizziamo il servizio di hosting All-Inkl, un'azienda tedesca. Quando accedi a questi strumenti, i tuoi dati personali vengono trasferiti in questo paese terzo e ivi potrebbero essere trattati.
+Per l'hosting utilizziamo Cloudflare Pages, un servizio fornito da Cloudflare, Inc., con sede negli Stati Uniti. Quando accedete al nostro sito Web, i dati tecnicamente necessari (in particolare il vostro indirizzo IP e i metadati della richiesta) vengono trasferiti negli Stati Uniti e ivi elaborati, poiché Cloudflare termina la connessione come reverse proxy / Content Delivery Network.
+
+Base giuridica per il trasferimento dei dati negli Stati Uniti: Cloudflare è certificata ai sensi del [Data Privacy Framework UE–USA](https://www.dataprivacyframework.gov/) e dello Swiss-U.S. Data Privacy Framework. Inoltre ci basiamo sulle clausole contrattuali standard della Commissione Europea. Nonostante queste garanzie, non si può escludere completamente un accesso da parte delle autorità statunitensi (ad esempio ai sensi del CLOUD Act).
 
 ### Crittografia SSL o TLS
 


### PR DESCRIPTION
## Summary

Datenschutzerklärung in allen vier Sprachen (de/en/fr/it) aktualisiert: All-Inkl raus, Cloudflare Pages rein.

- Section 4 (Hosting): Anbieter, Adresse, Privacy Policy + DPA-Link
- Drittland-Hinweis: USA-Transfer (IP + Request-Metadaten), Rechtsgrundlagen EU-U.S. DPF + Swiss-U.S. DPF + ergänzend SCCs, Hinweis CLOUD Act

## Hintergrund

`dfx.swiss` (landing-page) wurde via [landing-page#119](https://github.com/DFXswiss/landing-page/pull/119) auf Cloudflare Pages migriert. Die Migration aller weiteren statischen DFX-Pages auf CF Pages ist im Gange.

## ⚠️ Reihenfolge — wichtig

Dieses Repo (`docs`) deployed selbst noch via FTP zu All-Inkl (`.github/workflows/dev.yaml`, `prd.yaml`). `docs.dfx.swiss` liegt also weiterhin auf All-Inkl, **nicht** auf Cloudflare.

→ Diesen PR erst mergen, **nachdem** auch `docs.dfx.swiss` auf Cloudflare Pages migriert ist. Sonst nennt die DSE einen Hoster, der für die Domain, auf der sie selbst ausgeliefert wird, faktisch falsch ist.

## Geänderte Dateien

- `src/de/privacy.md`
- `src/en/privacy.md`
- `src/fr/privacy.md`
- `src/it/privacy.md`

Strukturelle Änderungen: Header `### Hosting mit All-Inkl` → `### Hosting mit Cloudflare Pages` und der zugehörige Absatz im Drittland-Hinweis.

## Test plan

- [ ] DE/EN/FR/IT Text-Review (Rechtsabteilung / DSB)
- [ ] CF Pages migration für `docs.dfx.swiss` abgeschlossen
- [ ] Verifizieren dass Cloudflare DPF-Zertifizierung weiterhin aktiv ist (dataprivacyframework.gov)
- [ ] Anschließend merge-ready