### PR TITLE
feat: add robots.txt allowing search engines and AI crawlers

### DIFF
--- a/src/.vuepress/public/robots.txt
+++ b/src/.vuepress/public/robots.txt
@@ -1,0 +1,38 @@
+# robots.txt — DFX documentation (docs.dfx.swiss)
+#
+# Public documentation. We explicitly WANT both search engines and AI agents to
+# crawl, index, and learn from this content. This file is version-controlled in
+# this repository and is the authoritative crawl policy for this site.
+#
+# Content signals: all uses are granted — search, AI input / retrieval-augmented
+# generation, and AI training. We deliberately do NOT signal ai-train=no.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Major AI crawlers are explicitly welcome. Some honor only their own named
+# record, so each is listed in addition to the wildcard group above.
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /


### PR DESCRIPTION
## Add repo-controlled robots.txt that allows search engines and AI crawlers

This adds a version-controlled `robots.txt` for the public DFX documentation
(docs.dfx.swiss) that explicitly **allows** both search engines and AI agents
to crawl, index, and learn from the content.

### What
- New file: `src/.vuepress/public/robots.txt`
- VuePress copies everything in `.vuepress/public/` verbatim to the published
  site root, so it is served at `https://docs.dfx.swiss/robots.txt`.
- Grants all content signals — `search=yes, ai-input=yes, ai-train=yes` — and
  lists the major AI crawlers individually (ClaudeBot, GPTBot, Google-Extended,
  CCBot, Bytespider, Amazonbot, Applebot-Extended, meta-externalagent) in
  addition to the wildcard group, because some bots honor only their own named
  record.

### Why
The documentation is public and we want it discoverable by search and usable as
input for AI agents / RAG and training. Keeping the policy in the repo makes it
authoritative and reviewable.

### No Sitemap line
The site does not serve or generate a sitemap: `GET /sitemap.xml` returns a
soft-404 (`text/html`, the SPA `404.html`), and the VuePress build output
contains no `sitemap.xml`. A `Sitemap:` directive was therefore intentionally
omitted.

### Verification
- Built locally with `npm run build`; confirmed `robots.txt` lands at the
  published root (`dist/robots.txt`) with identical content.

### Note on activation
This file becomes the effective crawl policy only once the site's hosting-level
"Manage robots.txt / Block AI bots" toggle is disabled at the CDN, so that the
repo-served file is what visitors and crawlers receive.
