### PR TITLE
docs: remove Telegram support channel from FAQ (all languages)

### DIFF
--- a/src/de/faq.md
+++ b/src/de/faq.md
@@ -4,8 +4,7 @@ Diese Seite beinhaltet die häufigsten Fragen zu DFX.swiss.
 
 ## Wo erhalte ich bei Fragen Unterstützung?
 DFX bietet auf unterschiedliche Weisen Unterstützung an. Du findest Informationen zu unseren Produkten und unserem Service auf unserer Homepage oder hier im FAQ. 
-Wir empfehlen generell, die Unterstützung unserer Moderatoren in Anspruch zu nehmen. 
-Tritt dafür unserer [Telegram Gruppe](https://t.me/DFXswiss) bei. Unsere Moderatoren unterstützen dich bei technischen Unklarheiten und bei Fragen bezüglich des Transaktionsstatus. Andernfalls kannst du dich auch an unseren [Support](http://dfx.swiss/help) wenden.
+Bei weiteren Fragen wende dich an unseren [Support](https://dfx.swiss/help).
 
 ## Was genau beinhaltet der Service von DFX?
 DFX ist die Brücke zwischen der Bank und dem Krypto-Space und ermöglicht somit Privat- & Firmenkunden Kryptowährungen zu kaufen und zu verkaufen. Wir arbeiten daran, unser Angebot auf möglichst viele Blockchains auszuweiten. Informationen zu unserem aktuellen Angebot findest du auf unserer [Homepage](https://dfx.swiss/de/).
@@ -129,20 +128,9 @@ Einige Banken blockieren gelegentlich SEPA-Überweisungen an Krypto-Dienstleiste
 
 ## DFX Metamask Exchange
 
-## Wo finde ich Informationen zur MetaMask?
-Das gesamte MetaMask Kompendium findest du [hier](https://t.me/DFXswiss/86011).
-
-Einige Unterthemen kannst du folgenden Beiträgen entnehmen:
-- [Einrichten der MetaMask](https://t.me/DFXswiss/85947)
-- [DFX Swiss und MetaMask verbinden](https://t.me/DFXswiss/85968)
-- [DFX Exchange - Kaufauftrag (Buy) vorbereiten](https://t.me/DFXswiss/86011)
-- [DFX Exchange - Verkauf (Sell)](https://t.me/DFXswiss/96022)
-
 ### MetaMask & Arbitrum 
 Arbitrum ist eine Second-Layer-Lösung für die ETH-Blockchain.
 Es reduziert die hohen Transaktionsgebühren & Mindesttransaktionsbeträge.
-
-Mehr Details findest du [hier](https://t.me/DFXswiss/92213).
 
 ## Bitcoin
 
@@ -158,25 +146,16 @@ Mit hoher Wahrscheinlichkeit sind die meisten Wallets kompatibel. Wir haben die 
 Klicke in der BlueWallet auf "Wallet hinzufügen". Klicke anschliessend auf "Wallet importieren", trage die 12 Wörter (Seed) ein und klicke auf "Importieren". Nun hast du deine Wallet erfolgreich in die BlueWallet übertragen. 
 
 ### Wo finde ich Informationen zum Bitcoin-spezifischen Service von DFX?
-Nachfolgend findest du Links zu Artikeln und Videos, die zu diesem Thema z.B. in unserer Telegram Gruppe oder auf YouTube bereitgestellt wurden.
+Nachfolgend findest du Links zu Artikeln und Videos, die zu diesem Thema z.B. auf YouTube bereitgestellt wurden.
 
-Meldung in der Bitcoin (BTC) only App "Backup nicht verifiziert"
-
-- [Erklärung](https://t.me/DFXswiss/91021)
 - [YouTube-Tutorial von Oli](https://youtu.be/CPYjvBC2NRs)
-- [Global senden](https://t.me/DFXswiss/99843)
-- [BTC Wallet bereits vorhanden?](https://t.me/DFXswiss/84476)  
 - [DFX Seed Phrase Template (PDF-Download)](https://dfx.swiss/wp-content/uploads/2022/11/221124_DFX_Seedphrase_Template_EN.pdf)
 - [Native Bitcoin kaufen](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Kaufen.mp4)
 - [Native Bitcoin verkaufen](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Verkaufen1.mp4)
 
 Achtung: Die Videos wurden vor der Einführung der neuen DFX-Gebührenstruktur erstellt und zeigen daher noch die DFX-Gebühren vor dem 01. Dezember 2022.
 
-- [Bestehendes DFX KYC auch mit der BTC only App verwenden](https://t.me/DFXswiss/84097)
-
-Anschliessend kann gerne SEPA Instant oder Standard SEPA benutzt werden. Weitere Informationen hierzu finden sich [hier](https://t.me/DFXswiss/71068).
-
-- [Wichtige Informationen zum BTC-Kurs beim Kauf](https://t.me/DFXswiss/85437)
+Anschliessend kann gerne SEPA Instant oder Standard SEPA benutzt werden.
 
 Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](https://dfx.swiss/help) wenden.
 
@@ -185,7 +164,6 @@ Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](h
 - Ledger
 - Trezor 
 
-[Klicke hier um zu erfahren, wie man Krypto-Assets mit der neuen Toolbox kauft oder verkauft](https://t.me/DFXswiss/85437)  
 Investiere entweder einmalig oder per Dauerauftrag (DCA) direkt in deine Hardware-Wallet!
 
 Mehr dazu auf YouTube in diesem Tutorial-Video: [Crypto recovery](https://www.youtube.com/watch?v=pUQnjZZho38)
@@ -201,7 +179,6 @@ Du kannst dich auch mittels manueller Eingabe von einer Blockchainadresse und pa
 ## Wie ist der Stand meiner Transaktion? Ich habe meine Krypto-Assets nicht erhalten.
 Wenn du eine Transaktion vorgenommen hast, und Fragen zu dieser Transaktion hast, weil du die Krypto-Assets noch nicht erhalten hast, dann hast du folgende Möglichkeiten:
 - Wenn es eine Banktransaktion war, empfehlen wir zwingend 2 Arbeitstage abzuwarten. Banktransaktionen werden in der Regel innert weniger Stunden verarbeitet, können im Extremfall aber auch einmal 3 Arbeitstage benötigen. Wir empfehlen daher, zuerst 2 Arbeitstage abzuwarten, bevor eine Nachforschung gestartet wird.
-- Du kannst im [DFX Telegram Chat](https://t.me/DFXswiss) nachfragen. Die Moderatoren reagieren dort sehr schnell auf Anfragen und können meistens rasch helfen. Bitte beachte, dass dich nie ein (echter) DFX-Mitarbeiter per Privatnachricht anschreiben wird! Wenn dich ein vermeintlicher DFX-Mitarbeiter per privater nachricht anschreibt, dann ist es ein Betrüger und kein echter DFX-Mitarbeiter. DFX-Mitarbeiter schreiben dir nur in der öffentlichen Telegram-Gruppe oder nur in einem privaten Chat, der von dir begonnen und eröffnet wurde, niemals aber in einam privaten Chat, der nicht von dir selbst gestartet wurde!
 - Des Weiteren kann auch der [Support](https://dfx.swiss/help) über die Webseite kontaktiert werden.
 
 ## Welche Daten müssen in einer Support-Anfrage mitgesendet werden?

--- a/src/en/faq.md
+++ b/src/en/faq.md
@@ -4,8 +4,7 @@ This page contains the most frequently asked questions about DFX.swiss.
 
 ## Where can I get support if I have questions?
 DFX offers support in different ways. You can find information about our products and services on our homepage or here in the FAQ. 
-We generally recommend using the support of our moderators. 
-Join our [Telegram group](https://t.me/DFXswiss) for this purpose. Our moderators will help you with technical issues and questions regarding transaction status. Otherwise, you can also contact our [Support](http://dfx.swiss/help).
+If you have any further questions, please contact our [Support](https://dfx.swiss/help).
 
 ## What exactly does the DFX service include?
 DFX is the bridge between the bank and the crypto space, enabling private and corporate customers to buy and sell cryptocurrencies. We are working to expand our offering to as many blockchains as possible. Information about our current offering can be found on our [homepage](https://dfx.swiss/en/).
@@ -129,20 +128,9 @@ Some banks occasionally block SEPA transfers to crypto service providers. If a t
 
 ## DFX Metamask Exchange
 
-## Where can I find information about MetaMask?
-The complete MetaMask compendium can be found [here](https://t.me/DFXswiss/86011).
-
-You can find some sub-topics in the following posts:
-- [Setting up MetaMask](https://t.me/DFXswiss/85947)
-- [Connecting DFX Swiss and MetaMask](https://t.me/DFXswiss/85968)
-- [DFX Exchange - Preparing a buy order](https://t.me/DFXswiss/86011)
-- [DFX Exchange - Sell](https://t.me/DFXswiss/96022)
-
 ### MetaMask & Arbitrum 
 Arbitrum is a second-layer solution for the ETH blockchain.
 It reduces the high transaction fees & minimum transaction amounts.
-
-More details can be found [here](https://t.me/DFXswiss/92213).
 
 ## Bitcoin
 
@@ -158,25 +146,16 @@ Most wallets are likely to be compatible. We have particularly tested compatibil
 In BlueWallet, click on "Add wallet". Then click on "Import wallet", enter the 12 words (seed) and click on "Import". Now you have successfully transferred your wallet to BlueWallet. 
 
 ### Where can I find information about DFX's Bitcoin-specific service?
-Below you will find links to articles and videos that have been provided on this topic, for example, in our Telegram group or on YouTube.
+Below you will find links to articles and videos that have been provided on this topic, for example, on YouTube.
 
-Message in the Bitcoin (BTC) only app "Backup not verified"
-
-- [Explanation](https://t.me/DFXswiss/91021)
 - [YouTube tutorial by Oli](https://youtu.be/CPYjvBC2NRs)
-- [Send globally](https://t.me/DFXswiss/99843)
-- [BTC wallet already available?](https://t.me/DFXswiss/84476)  
 - [DFX Seed Phrase Template (PDF download)](https://dfx.swiss/wp-content/uploads/2022/11/221124_DFX_Seedphrase_Template_EN.pdf)
 - [Buy native Bitcoin](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Kaufen.mp4)
 - [Sell native Bitcoin](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Verkaufen1.mp4)
 
 Attention: The videos were created before the introduction of the new DFX fee structure and therefore still show the DFX fees before December 1, 2022.
 
-- [Use existing DFX KYC with the BTC only app](https://t.me/DFXswiss/84097)
-
-SEPA Instant or standard SEPA can then be used. Further information can be found [here](https://t.me/DFXswiss/71068).
-
-- [Important information about the BTC rate when buying](https://t.me/DFXswiss/85437)
+SEPA Instant or standard SEPA can then be used.
 
 If you have questions or uncertainties about this, you can simply contact our [Support](https://dfx.swiss/help).
 
@@ -185,7 +164,6 @@ If you have questions or uncertainties about this, you can simply contact our [S
 - Ledger
 - Trezor 
 
-[Click here to learn how to buy or sell crypto assets with the new toolbox](https://t.me/DFXswiss/85437)  
 Invest either once or via standing order (DCA) directly into your hardware wallet!
 
 More on YouTube in this tutorial video: [Crypto recovery](https://www.youtube.com/watch?v=pUQnjZZho38)
@@ -201,7 +179,6 @@ You can also log in to DFX by manually entering a blockchain address and matchin
 ## What is the status of my transaction? I have not received my crypto assets.
 If you have made a transaction and have questions about this transaction because you have not yet received the crypto assets, you have the following options:
 - If it was a bank transaction, we strongly recommend waiting 2 business days. Bank transactions are usually processed within a few hours, but in extreme cases can also take 3 business days. We therefore recommend waiting 2 business days before starting an investigation.
-- You can ask in the [DFX Telegram chat](https://t.me/DFXswiss). The moderators there respond very quickly to inquiries and can usually help quickly. Please note that a (real) DFX employee will never write to you via private message! If a supposed DFX employee writes to you via private message, it is a scammer and not a real DFX employee. DFX employees will only write to you in the public Telegram group or only in a private chat that was started and opened by you, never in a private chat that was not started by you yourself!
 - You can also contact [Support](https://dfx.swiss/help) via the website.
 
 ## Which data must be included in a support request?

--- a/src/fr/faq.md
+++ b/src/fr/faq.md
@@ -4,8 +4,7 @@ Cette page contient les questions les plus fréquemment posées sur DFX.swiss.
 
 ## Où puis-je obtenir de l'aide si j'ai des questions ?
 DFX offre un support de différentes manières. Vous pouvez trouver des informations sur nos produits et services sur notre page d'accueil ou ici dans la FAQ. 
-Nous recommandons généralement d'utiliser le support de nos modérateurs. 
-Rejoignez notre [groupe Telegram](https://t.me/DFXswiss) à cette fin. Nos modérateurs vous aideront avec les problèmes techniques et les questions concernant le statut des transactions. Sinon, vous pouvez également contacter notre [Support](http://dfx.swiss/help).
+Pour toute autre question, contactez notre [Support](https://dfx.swiss/help).
 
 ## Qu'est-ce que le service DFX inclut exactement ?
 DFX est le pont entre la banque et l'espace crypto, permettant aux clients privés et professionnels d'acheter et de vendre des cryptomonnaies. Nous travaillons à étendre notre offre à autant de blockchains que possible. Des informations sur notre offre actuelle peuvent être trouvées sur notre [page d'accueil](https://dfx.swiss/fr/).
@@ -129,20 +128,9 @@ Certaines banques bloquent occasionnellement les virements SEPA vers les fournis
 
 ## DFX Metamask Exchange
 
-## Où puis-je trouver des informations sur MetaMask ?
-Le compendium complet MetaMask peut être trouvé [ici](https://t.me/DFXswiss/86011).
-
-Vous pouvez trouver certains sous-thèmes dans les publications suivantes :
-- [Configuration de MetaMask](https://t.me/DFXswiss/85947)
-- [Connexion de DFX Swiss et MetaMask](https://t.me/DFXswiss/85968)
-- [DFX Exchange - Préparation d'un ordre d'achat](https://t.me/DFXswiss/86011)
-- [DFX Exchange - Vente](https://t.me/DFXswiss/96022)
-
 ### MetaMask & Arbitrum 
 Arbitrum est une solution de deuxième couche pour la blockchain ETH.
 Il réduit les frais de transaction élevés et les montants de transaction minimums.
-
-Plus de détails peuvent être trouvés [ici](https://t.me/DFXswiss/92213).
 
 ## Bitcoin
 
@@ -158,25 +146,16 @@ La plupart des portefeuilles sont probablement compatibles. Nous avons particuli
 Dans BlueWallet, cliquez sur "Ajouter un portefeuille". Cliquez ensuite sur "Importer un portefeuille", entrez les 12 mots (seed) et cliquez sur "Importer". Vous avez maintenant transféré avec succès votre portefeuille vers BlueWallet. 
 
 ### Où puis-je trouver des informations sur le service spécifique Bitcoin de DFX ?
-Vous trouverez ci-dessous des liens vers des articles et des vidéos qui ont été fournis sur ce sujet, par exemple, dans notre groupe Telegram ou sur YouTube.
+Vous trouverez ci-dessous des liens vers des articles et des vidéos qui ont été fournis sur ce sujet, par exemple, sur YouTube.
 
-Message dans l'application Bitcoin (BTC) uniquement "Sauvegarde non vérifiée"
-
-- [Explication](https://t.me/DFXswiss/91021)
 - [Tutoriel YouTube par Oli](https://youtu.be/CPYjvBC2NRs)
-- [Envoyer globalement](https://t.me/DFXswiss/99843)
-- [Portefeuille BTC déjà disponible ?](https://t.me/DFXswiss/84476)  
 - [Modèle de phrase seed DFX (téléchargement PDF)](https://dfx.swiss/wp-content/uploads/2022/11/221124_DFX_Seedphrase_Template_EN.pdf)
 - [Acheter du Bitcoin natif](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Kaufen.mp4)
 - [Vendre du Bitcoin natif](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Verkaufen1.mp4)
 
 Attention : Les vidéos ont été créées avant l'introduction de la nouvelle structure de frais DFX et montrent donc encore les frais DFX avant le 1er décembre 2022.
 
-- [Utiliser le KYC DFX existant avec l'application BTC uniquement](https://t.me/DFXswiss/84097)
-
-SEPA Instant ou SEPA standard peut ensuite être utilisé. De plus amples informations peuvent être trouvées [ici](https://t.me/DFXswiss/71068).
-
-- [Informations importantes sur le taux BTC lors de l'achat](https://t.me/DFXswiss/85437)
+SEPA Instant ou SEPA standard peut ensuite être utilisé.
 
 Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simplement contacter notre [Support](https://dfx.swiss/help).
 
@@ -185,7 +164,6 @@ Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simpleme
 - Ledger
 - Trezor 
 
-[Cliquez ici pour apprendre comment acheter ou vendre des actifs crypto avec la nouvelle boîte à outils](https://t.me/DFXswiss/85437)  
 Investissez soit une fois, soit via un ordre permanent (DCA) directement dans votre portefeuille matériel !
 
 Plus sur YouTube dans cette vidéo tutoriel : [Récupération crypto](https://www.youtube.com/watch?v=pUQnjZZho38)
@@ -201,7 +179,6 @@ Vous pouvez également vous connecter à DFX en saisissant manuellement une adre
 ## Quel est le statut de ma transaction ? Je n'ai pas reçu mes actifs crypto.
 Si vous avez effectué une transaction et avez des questions sur cette transaction parce que vous n'avez pas encore reçu les actifs crypto, vous avez les options suivantes :
 - S'il s'agissait d'une transaction bancaire, nous recommandons fortement d'attendre 2 jours ouvrables. Les transactions bancaires sont généralement traitées en quelques heures, mais dans des cas extrêmes peuvent également prendre 3 jours ouvrables. Nous recommandons donc d'attendre 2 jours ouvrables avant de commencer une enquête.
-- Vous pouvez demander dans le [chat Telegram DFX](https://t.me/DFXswiss). Les modérateurs y répondent très rapidement aux demandes et peuvent généralement aider rapidement. Veuillez noter qu'un (vrai) employé DFX ne vous écrira jamais par message privé ! Si un soi-disant employé DFX vous écrit par message privé, c'est un escroc et non un vrai employé DFX. Les employés DFX ne vous écriront que dans le groupe Telegram public ou uniquement dans un chat privé qui a été démarré et ouvert par vous, jamais dans un chat privé qui n'a pas été démarré par vous-même !
 - Vous pouvez également contacter le [Support](https://dfx.swiss/help) via le site Web.
 
 ## Quelles données doivent être incluses dans une demande de support ?

--- a/src/it/faq.md
+++ b/src/it/faq.md
@@ -4,8 +4,7 @@ Questa pagina contiene le domande più frequenti su DFX.swiss.
 
 ## Dove posso ottenere supporto se ho domande?
 DFX offre supporto in diversi modi. Puoi trovare informazioni sui nostri prodotti e servizi sulla nostra homepage o qui nelle FAQ. 
-Generalmente raccomandiamo di utilizzare il supporto dei nostri moderatori. 
-Unisciti al nostro [gruppo Telegram](https://t.me/DFXswiss) a questo scopo. I nostri moderatori ti aiuteranno con problemi tecnici e domande riguardanti lo stato delle transazioni. Altrimenti, puoi anche contattare il nostro [Supporto](http://dfx.swiss/help).
+Per ulteriori domande, contatta il nostro [Supporto](https://dfx.swiss/help).
 
 ## Cosa include esattamente il servizio DFX?
 DFX è il ponte tra la banca e lo spazio crypto, consentendo ai clienti privati e aziendali di acquistare e vendere criptovalute. Stiamo lavorando per espandere la nostra offerta a quante più blockchain possibile. Informazioni sulla nostra offerta attuale possono essere trovate sulla nostra [homepage](https://dfx.swiss/it/).
@@ -129,20 +128,9 @@ Alcune banche occasionalmente bloccano i bonifici SEPA ai fornitori di servizi c
 
 ## DFX Metamask Exchange
 
-## Dove posso trovare informazioni su MetaMask?
-Il compendio completo MetaMask può essere trovato [qui](https://t.me/DFXswiss/86011).
-
-Puoi trovare alcuni sotto-argomenti nei seguenti post:
-- [Configurazione di MetaMask](https://t.me/DFXswiss/85947)
-- [Connessione di DFX Swiss e MetaMask](https://t.me/DFXswiss/85968)
-- [DFX Exchange - Preparazione di un ordine di acquisto](https://t.me/DFXswiss/86011)
-- [DFX Exchange - Vendita](https://t.me/DFXswiss/96022)
-
 ### MetaMask & Arbitrum 
 Arbitrum è una soluzione di secondo livello per la blockchain ETH.
 Riduce le elevate commissioni di transazione e gli importi minimi di transazione.
-
-Maggiori dettagli possono essere trovati [qui](https://t.me/DFXswiss/92213).
 
 ## Bitcoin
 
@@ -158,25 +146,16 @@ La maggior parte dei portafogli è probabilmente compatibile. Abbiamo particolar
 In BlueWallet, fai clic su "Aggiungi portafoglio". Quindi fai clic su "Importa portafoglio", inserisci le 12 parole (seed) e fai clic su "Importa". Ora hai trasferito con successo il tuo portafoglio a BlueWallet. 
 
 ### Dove posso trovare informazioni sul servizio specifico Bitcoin di DFX?
-Di seguito troverai link ad articoli e video che sono stati forniti su questo argomento, ad esempio, nel nostro gruppo Telegram o su YouTube.
+Di seguito troverai link ad articoli e video che sono stati forniti su questo argomento, ad esempio, su YouTube.
 
-Messaggio nell'app Bitcoin (BTC) solo "Backup non verificato"
-
-- [Spiegazione](https://t.me/DFXswiss/91021)
 - [Tutorial YouTube di Oli](https://youtu.be/CPYjvBC2NRs)
-- [Invia globalmente](https://t.me/DFXswiss/99843)
-- [Portafoglio BTC già disponibile?](https://t.me/DFXswiss/84476)  
 - [Modello di frase seed DFX (download PDF)](https://dfx.swiss/wp-content/uploads/2022/11/221124_DFX_Seedphrase_Template_EN.pdf)
 - [Acquista Bitcoin nativo](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Kaufen.mp4)
 - [Vendi Bitcoin nativo](https://dfx.swiss/wp-content/uploads/2022/11/Bitcoin-Wallet-Beta-Verkaufen1.mp4)
 
 Attenzione: I video sono stati creati prima dell'introduzione della nuova struttura delle commissioni DFX e mostrano quindi ancora le commissioni DFX prima del 1° dicembre 2022.
 
-- [Usa il KYC DFX esistente con l'app BTC solo](https://t.me/DFXswiss/84097)
-
-SEPA Instant o SEPA standard può quindi essere utilizzato. Ulteriori informazioni possono essere trovate [qui](https://t.me/DFXswiss/71068).
-
-- [Informazioni importanti sul tasso BTC durante l'acquisto](https://t.me/DFXswiss/85437)
+SEPA Instant o SEPA standard può quindi essere utilizzato.
 
 Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [Supporto](https://dfx.swiss/help).
 
@@ -185,7 +164,6 @@ Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [
 - Ledger
 - Trezor 
 
-[Fai clic qui per imparare come acquistare o vendere asset crypto con la nuova toolbox](https://t.me/DFXswiss/85437)  
 Investi una volta o tramite ordine permanente (DCA) direttamente nel tuo portafoglio hardware!
 
 Maggiori informazioni su YouTube in questo video tutorial: [Recupero crypto](https://www.youtube.com/watch?v=pUQnjZZho38)
@@ -201,7 +179,6 @@ Puoi anche accedere a DFX inserendo manualmente un indirizzo blockchain e una fi
 ## Qual è lo stato della mia transazione? Non ho ricevuto i miei asset crypto.
 Se hai effettuato una transazione e hai domande su questa transazione perché non hai ancora ricevuto gli asset crypto, hai le seguenti opzioni:
 - Se si trattava di una transazione bancaria, raccomandiamo vivamente di attendere 2 giorni lavorativi. Le transazioni bancarie vengono solitamente elaborate entro poche ore, ma in casi estremi possono anche richiedere 3 giorni lavorativi. Raccomandiamo quindi di attendere 2 giorni lavorativi prima di avviare un'indagine.
-- Puoi chiedere nella [chat Telegram DFX](https://t.me/DFXswiss). I moderatori lì rispondono molto rapidamente alle richieste e possono solitamente aiutare rapidamente. Si prega di notare che un (vero) dipendente DFX non ti scriverà mai tramite messaggio privato! Se un presunto dipendente DFX ti scrive tramite messaggio privato, è un truffatore e non un vero dipendente DFX. I dipendenti DFX ti scriveranno solo nel gruppo Telegram pubblico o solo in una chat privata che è stata avviata e aperta da te, mai in una chat privata che non è stata avviata da te stesso!
 - Puoi anche contattare il [Supporto](https://dfx.swiss/help) tramite il sito web.
 
 ## Quali dati devono essere inclusi in una richiesta di supporto?


### PR DESCRIPTION
Removes every reference to the Telegram support channel from the FAQ in all four languages (de/en/fr/it) — 15 mentions per language, 60 total. dfx.swiss and app.dfx.swiss no longer offer Telegram support, so the docs must not point users there.

## Changes
- **Support answer**: now points to [dfx.swiss/help](https://dfx.swiss/help) only (also fixes the previous plain-http link)
- **Transaction-status help**: Telegram bullet removed (including the Telegram-specific scam warning); ticket support remains
- **MetaMask section**: the "Where can I find information about MetaMask?" Q&A consisted exclusively of t.me deep links and was removed entirely; the Arbitrum explanation stays
- **Bitcoin section**: t.me deep links removed, YouTube/PDF/video links kept; dangling "Backup not verified" label removed with its t.me explanation link
- **Toolbox/hardware wallet**: t.me tutorial link removed

## Note for review
The MetaMask setup/buy/sell tutorials existed **only** as Telegram posts — that content is now gone from the docs without a replacement. If those guides should survive, they need a new home (e.g. docs pages) in a follow-up.

Verified: `grep -ri "telegram\|t\.me" src/*/faq.md` returns 0 matches, VuePress build succeeds, rendered HTML clean in all four languages.