### PR TITLE
docs: add Swissquote/Yuh payment FAQ entry (de/en/fr/it)

### DIFF
--- a/src/de/faq.md
+++ b/src/de/faq.md
@@ -131,9 +131,7 @@ Nein. Der Zahlungsweg zwischen Swissquote bzw. Yuh und DFX ist eingeschr채nkt. �
 
 Bitte verwende f체r deine Einzahlung ein Konto bei einer anderen Bank, das auf deinen Namen lautet.
 
-Ist bereits eine Zahlung von einem Swissquote- oder Yuh-Konto bei uns eingegangen, kann diese nicht verarbeitet werden und muss auf ein anderes, auf deinen Namen lautendes Bankkonto zur체ck체berwiesen werden.
-
-Bitte wende dich in diesem Fall an unseren Support.
+Ist bereits eine Zahlung von einem Swissquote- oder Yuh-Konto bei uns eingegangen, 체berweisen wir diese auf ein anderes, auf deinen Namen lautendes Bankkonto zur체ck. Bitte wende dich dazu an unseren Support.
 
 ## DFX Metamask Exchange
 

--- a/src/de/faq.md
+++ b/src/de/faq.md
@@ -126,6 +126,15 @@ Nein. Wir möchten, dass du so viele Freunde und Bekannte wie möglich von unser
 ## Gibt es Banken die Überweisungen an DFX blockieren?
 Einige Banken blockieren gelegentlich SEPA-Überweisungen an Krypto-Dienstleister. Falls eine Überweisung abgelehnt wird, empfehlen wir, direkt mit der eigenen Bank Kontakt aufzunehmen, um die Zahlung freizugeben. Alternativ kann eine andere Bank oder ein Zahlungsdienstleister für die Überweisung genutzt werden.
 
+## Werden Zahlungen von Swissquote oder Yuh unterstützt?
+Nein. Der Zahlungsweg zwischen Swissquote bzw. Yuh und DFX ist eingeschränkt. Überweisungen von Konten bei Swissquote oder Yuh können daher von uns nicht verarbeitet werden.
+
+Bitte verwende für deine Einzahlung ein Konto bei einer anderen Bank, das auf deinen Namen lautet.
+
+Ist bereits eine Zahlung von einem Swissquote- oder Yuh-Konto bei uns eingegangen, kann diese nicht verarbeitet werden und muss auf ein anderes, auf deinen Namen lautendes Bankkonto zurücküberwiesen werden.
+
+Bitte wende dich in diesem Fall an unseren Support.
+
 ## DFX Metamask Exchange
 
 ### MetaMask & Arbitrum 

--- a/src/en/faq.md
+++ b/src/en/faq.md
@@ -131,9 +131,7 @@ No. The payment channel between Swissquote or Yuh and DFX is restricted. Transfe
 
 Please use an account at another bank in your own name for your deposit.
 
-If a payment from a Swissquote or Yuh account has already reached us, it cannot be processed and must be transferred back to another bank account in your name.
-
-In this case, please contact our support.
+If a payment from a Swissquote or Yuh account has already reached us, we will transfer it back to another bank account in your name. Please contact our support for this.
 
 ## DFX Metamask Exchange
 

--- a/src/en/faq.md
+++ b/src/en/faq.md
@@ -126,6 +126,15 @@ No. We want you to convince as many friends and acquaintances as possible of our
 ## Are there banks that block transfers to DFX?
 Some banks occasionally block SEPA transfers to crypto service providers. If a transfer is rejected, we recommend contacting your own bank directly to release the payment. Alternatively, another bank or payment service provider can be used for the transfer.
 
+## Are payments from Swissquote or Yuh supported?
+No. The payment channel between Swissquote or Yuh and DFX is restricted. Transfers from accounts at Swissquote or Yuh can therefore not be processed by us.
+
+Please use an account at another bank in your own name for your deposit.
+
+If a payment from a Swissquote or Yuh account has already reached us, it cannot be processed and must be transferred back to another bank account in your name.
+
+In this case, please contact our support.
+
 ## DFX Metamask Exchange
 
 ### MetaMask & Arbitrum 

--- a/src/fr/faq.md
+++ b/src/fr/faq.md
@@ -126,6 +126,15 @@ Non. Nous voulons que vous convainquiez autant d'amis et de connaissances que po
 ## Y a-t-il des banques qui bloquent les virements vers DFX ?
 Certaines banques bloquent occasionnellement les virements SEPA vers les fournisseurs de services crypto. Si un virement est rejeté, nous recommandons de contacter directement votre propre banque pour libérer le paiement. Alternativement, une autre banque ou un autre prestataire de services de paiement peut être utilisé pour le virement.
 
+## Les paiements depuis Swissquote ou Yuh sont-ils pris en charge ?
+Non. Le canal de paiement entre Swissquote ou Yuh et DFX est restreint. Les virements provenant de comptes Swissquote ou Yuh ne peuvent donc pas être traités par nos soins.
+
+Veuillez utiliser pour votre dépôt un compte à votre nom auprès d'une autre banque.
+
+Si un paiement provenant d'un compte Swissquote ou Yuh nous est déjà parvenu, il ne peut pas être traité et doit être reversé sur un autre compte bancaire à votre nom.
+
+Dans ce cas, veuillez contacter notre support.
+
 ## DFX Metamask Exchange
 
 ### MetaMask & Arbitrum 

--- a/src/fr/faq.md
+++ b/src/fr/faq.md
@@ -131,9 +131,7 @@ Non. Le canal de paiement entre Swissquote ou Yuh et DFX est restreint. Les vire
 
 Veuillez utiliser pour votre dépôt un compte à votre nom auprès d'une autre banque.
 
-Si un paiement provenant d'un compte Swissquote ou Yuh nous est déjà parvenu, il ne peut pas être traité et doit être reversé sur un autre compte bancaire à votre nom.
-
-Dans ce cas, veuillez contacter notre support.
+Si un paiement provenant d'un compte Swissquote ou Yuh nous est déjà parvenu, nous le reversons sur un autre compte bancaire à votre nom. Veuillez contacter notre support à ce sujet.
 
 ## DFX Metamask Exchange
 

--- a/src/it/faq.md
+++ b/src/it/faq.md
@@ -126,6 +126,15 @@ No. Vogliamo che tu convinca quanti più amici e conoscenti possibile del nostro
 ## Ci sono banche che bloccano i bonifici a DFX?
 Alcune banche occasionalmente bloccano i bonifici SEPA ai fornitori di servizi crypto. Se un bonifico viene rifiutato, raccomandiamo di contattare direttamente la propria banca per rilasciare il pagamento. In alternativa, può essere utilizzata un'altra banca o un altro fornitore di servizi di pagamento per il bonifico.
 
+## I pagamenti da Swissquote o Yuh sono supportati?
+No. Il canale di pagamento tra Swissquote o Yuh e DFX è limitato. I bonifici da conti presso Swissquote o Yuh non possono quindi essere elaborati da noi.
+
+Per il tuo deposito, utilizza un conto a tuo nome presso un'altra banca.
+
+Se un pagamento da un conto Swissquote o Yuh è già arrivato presso di noi, non può essere elaborato e deve essere ritrasferito su un altro conto bancario a tuo nome.
+
+In questo caso, contatta il nostro supporto.
+
 ## DFX Metamask Exchange
 
 ### MetaMask & Arbitrum 

--- a/src/it/faq.md
+++ b/src/it/faq.md
@@ -131,9 +131,7 @@ No. Il canale di pagamento tra Swissquote o Yuh e DFX è limitato. I bonifici da
 
 Per il tuo deposito, utilizza un conto a tuo nome presso un'altra banca.
 
-Se un pagamento da un conto Swissquote o Yuh è già arrivato presso di noi, non può essere elaborato e deve essere ritrasferito su un altro conto bancario a tuo nome.
-
-In questo caso, contatta il nostro supporto.
+Se un pagamento da un conto Swissquote o Yuh è già arrivato presso di noi, lo ritrasferiamo su un altro conto bancario a tuo nome. Contatta il nostro supporto a riguardo.
 
 ## DFX Metamask Exchange
 


### PR DESCRIPTION
Adds a new FAQ entry stating that payments from Swissquote and Yuh accounts are not supported, directly below the existing entry about banks blocking transfers to DFX.

- New entry in all four languages (de/en/fr/it)
- Explains that incoming payments from these banks cannot be processed and will be returned to another account in the customer's name
- Customers are directed to support in that case