### PR TITLE
019ffaf6 - Clarify Swissquote FAQ, support form and German privacy

### DIFF
--- a/src/de/faq.md
+++ b/src/de/faq.md
@@ -4,7 +4,7 @@ Diese Seite beinhaltet die häufigsten Fragen zu DFX.swiss.
 
 ## Wo erhalte ich bei Fragen Unterstützung?
 DFX bietet auf unterschiedliche Weisen Unterstützung an. Du findest Informationen zu unseren Produkten und unserem Service auf unserer Homepage oder hier im FAQ. 
-Bei weiteren Fragen wende dich an unseren [Support](https://dfx.swiss/help).
+Bei weiteren Fragen wende dich an unseren [Support](https://app.dfx.swiss/support).
 
 ## Was genau beinhaltet der Service von DFX?
 DFX ist die Brücke zwischen der Bank und dem Krypto-Space und ermöglicht somit Privat- & Firmenkunden Kryptowährungen zu kaufen und zu verkaufen. Wir arbeiten daran, unser Angebot auf möglichst viele Blockchains auszuweiten. Informationen zu unserem aktuellen Angebot findest du auf unserer [Homepage](https://dfx.swiss/de/).
@@ -21,7 +21,7 @@ DFX hat nur während des Kaufs beziehungsweise Verkaufs Zugriff auf das Geld des
 DFX akzeptiert SEPA- und SEPA-Instant-Überweisungen. Ob eine Überweisung möglich ist, hängt davon ab, ob die Bank des Kunden am SEPA-Zahlungsraum teilnimmt. Als VQF-Mitglied ist DFX den Sorgfaltspflichten des Schweizer Geldwäschereigesetzes (GwG) unterstellt. Geschäftsbeziehungen mit Personen in Jurisdiktionen, die von der FATF als Hochrisiko-Jurisdiktionen geführt werden, können nicht eingegangen werden. Die jeweils aktuelle Einstufung ist unter https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html einsehbar.
 
 ## Erhalte ich eine Übersicht aller Transaktionen, inklusive Fees, die ich während des Jahres bei DFX getätigt habe?
-Ja, du kannst eine Transaktionsübersicht zu den DFX Services bekommen (Kauf & Verkauf über Fiat und Referral Rewards). Diese kannst du auch für das Finanzamt verwenden. Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](https://dfx.swiss/help) wenden.
+Ja, du kannst eine Transaktionsübersicht zu den DFX Services bekommen (Kauf & Verkauf über Fiat und Referral Rewards). Diese kannst du auch für das Finanzamt verwenden. Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](https://app.dfx.swiss/support) wenden.
 
 ## Ist der Service auch für Unternehmenskunden verfügbar?
 Ja.
@@ -30,10 +30,10 @@ Ja.
 Es kann durchaus vorkommen, dass sich deine Bank bei dir meldet beziehungsweise eine Überweisung zu unserem Service abgelehnt hat. Dies soll dem Schutz des Kunden dienen, da Betrug oder andere kriminelle Machenschaften verdächtigt werden. In diesem Fall ist es ratsam, mit deiner Bank Kontakt aufzunehmen, damit deine Bank die Zahlung freigibt.
 
 ## Meine Bank verlangt einen Mittelherkunftsnachweis für meine Krypto-Verkäufe. Was muss ich tun?
-Gerne helfen wir Dir dabei und unterstützen Dich mit unseren Experten. In einem angenehmen Telefongespräch gehen wir alle relevanten Punkte durch und versuchen den Herkunft der Mittel unkompliziert und einfach zu dokumentieren. Gerne helfen wir dir dabei, die Auszahlung auf dein Bankkonto perfekt vorzubereiten, sodass du keine Probleme bekommst. Melde dich dazu einfach bei unserem [Support](https://dfx.swiss/help).
+Gerne helfen wir Dir dabei und unterstützen Dich mit unseren Experten. In einem angenehmen Telefongespräch gehen wir alle relevanten Punkte durch und versuchen den Herkunft der Mittel unkompliziert und einfach zu dokumentieren. Gerne helfen wir dir dabei, die Auszahlung auf dein Bankkonto perfekt vorzubereiten, sodass du keine Probleme bekommst. Melde dich dazu einfach bei unserem [Support](https://app.dfx.swiss/support).
 
 ### Welche Währungen werden von unserem Service unterstützt?
-Wir akzeptieren CHF und EUR. Bei Transaktionen, die 50'000,- CHF überschreiten, werden nach Absprache auch alternative Währungen akzeptiert. Melde dich in diesem Fall einfach bei unserem [Support](https://dfx.swiss/help).
+Wir akzeptieren CHF und EUR. Bei Transaktionen, die 50'000,- CHF überschreiten, werden nach Absprache auch alternative Währungen akzeptiert. Melde dich in diesem Fall einfach bei unserem [Support](https://app.dfx.swiss/support).
 
 ## Nutzer-relevante Fragen & KYC-Prozess
 
@@ -164,7 +164,7 @@ Achtung: Die Videos wurden vor der Einführung der neuen DFX-Gebührenstruktur e
 
 Anschliessend kann gerne SEPA Instant oder Standard SEPA benutzt werden.
 
-Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](https://dfx.swiss/help) wenden.
+Bei Fragen und Unklarheiten hierzu kannst du dich einfach an unseren [Support](https://app.dfx.swiss/support) wenden.
 
 ## Wie integriere ich die Hardware-Wallet?
 - BitBoxSwiss 
@@ -186,7 +186,7 @@ Du kannst dich auch mittels manueller Eingabe von einer Blockchainadresse und pa
 ## Wie ist der Stand meiner Transaktion? Ich habe meine Krypto-Assets nicht erhalten.
 Wenn du eine Transaktion vorgenommen hast, und Fragen zu dieser Transaktion hast, weil du die Krypto-Assets noch nicht erhalten hast, dann hast du folgende Möglichkeiten:
 - Wenn es eine Banktransaktion war, empfehlen wir zwingend 2 Arbeitstage abzuwarten. Banktransaktionen werden in der Regel innert weniger Stunden verarbeitet, können im Extremfall aber auch einmal 3 Arbeitstage benötigen. Wir empfehlen daher, zuerst 2 Arbeitstage abzuwarten, bevor eine Nachforschung gestartet wird.
-- Des Weiteren kann auch der [Support](https://dfx.swiss/help) über die Webseite kontaktiert werden.
+- Des Weiteren kann auch der [Support](https://app.dfx.swiss/support) über die Webseite kontaktiert werden.
 
 ## Welche Daten müssen in einer Support-Anfrage mitgesendet werden?
 Bei Banktransaktionen benötigt der Support folgende Informationen:

--- a/src/de/faq.md
+++ b/src/de/faq.md
@@ -127,9 +127,9 @@ Nein. Wir möchten, dass du so viele Freunde und Bekannte wie möglich von unser
 Einige Banken blockieren gelegentlich SEPA-Überweisungen an Krypto-Dienstleister. Falls eine Überweisung abgelehnt wird, empfehlen wir, direkt mit der eigenen Bank Kontakt aufzunehmen, um die Zahlung freizugeben. Alternativ kann eine andere Bank oder ein Zahlungsdienstleister für die Überweisung genutzt werden.
 
 ## Werden Zahlungen von Swissquote oder Yuh unterstützt?
-Nein. Der Zahlungsweg zwischen Swissquote bzw. Yuh und DFX ist eingeschränkt. Überweisungen von Konten bei Swissquote oder Yuh können daher von uns nicht verarbeitet werden.
+Nein. Die Blockierung kommt von Swissquote bzw. Yuh, nicht von DFX. Wir können das von unserer Seite nicht ändern. Dafür bitten wir die betroffenen Nutzer um Entschuldigung.
 
-Bitte verwende für deine Einzahlung ein Konto bei einer anderen Bank, das auf deinen Namen lautet.
+Überweisungen von Konten bei Swissquote oder Yuh können wir daher nicht verarbeiten. Bitte verwende für deine Einzahlung ein Konto bei einer anderen Bank, das auf deinen Namen lautet.
 
 Ist bereits eine Zahlung von einem Swissquote- oder Yuh-Konto bei uns eingegangen, überweisen wir diese auf ein anderes, auf deinen Namen lautendes Bankkonto zurück. Bitte wende dich dazu an unseren Support.
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -23,6 +23,8 @@ Registergericht: Zug, Schweiz
 Website: https://dfx.swiss   
 Elektronische Kontaktaufnahme: https://app.dfx.swiss/support  
 
+Anfragen nehmen wir ausschliesslich über dieses Formular entgegen, damit wir die Pflichten aus dem Datenschutzgesetz — insbesondere Auskunft, Berichtigung und Löschung — korrekt erfüllen können. Eine E-Mail-Adresse bieten wir bewusst nicht an.
+
 
 ## 2. Allgemeine Informationen zum Datenschutz
 
@@ -30,7 +32,7 @@ DFX behandelt Ihre personenbezogenen Daten vertraulich und gemäss den gesetzlic
 
 Die Nutzung unserer Website ist in der Regel ohne Angabe personenbezogener Daten möglich. Sofern eine betroffene Person besondere Services unseres Unternehmens über unsere Internetseite in Anspruch nehmen möchte, könnte jedoch eine Verarbeitung personenbezogener Daten erforderlich werden. Ist die Verarbeitung personenbezogener Daten erforderlich und besteht für eine solche Verarbeitung keine gesetzliche Grundlage, holen wir nach angemessener Information die Einwilligung der betroffenen Person in geeigneter Form ein.  
 
-Wir weisen darauf hin, dass die Datenübertragung im Internet (zum Beispiel bei der Kommunikation per E-Mail) trotz der von uns getroffenen Sicherheitsvorkehrungen Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.  
+Wir weisen darauf hin, dass die Datenübertragung im Internet trotz der von uns getroffenen Sicherheitsvorkehrungen Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.  
 
 Als betroffene (natürliche) Person liegt es in Ihrem persönlichen Interesse, das/die von Ihnen genutzte(n) System(e) (PC, Laptop, etc.) vor dem unberechtigten Zugriff Dritter zu sichern, mit einem ausreichenden Passwortschutz zu versehen und das Passwort nicht an Dritte weiterzugeben. Es wird empfohlen, einen im Handel erhältlichen Virenschutz zu installieren und diesen regelmässig zu aktualisieren.
 
@@ -41,10 +43,11 @@ Im Rahmen unserer Geschäftsbeziehungen und der Nutzung unserer Dienste verarbei
 * Kontaktinformationen: z. B. Name, Adresse, Telefonnummer, E-Mail-Adresse.
 * Technische Daten: z. B. IP-Adressen, Geräteinformationen, Browser-Typ.
 * Zahlungs- und Finanzdaten: z. B. Bankverbindungen, Kreditkartendaten, Transaktionshistorie, Steuererklärung.
-* Kommunikationsdaten: z. B. Inhalte von E-Mails, Kontaktformularen, Anfragen.
+* Kommunikationsdaten: z. B. Inhalte von Anfragen über das Support-Formular.
 * Nutzungsdaten: z. B. besuchte Seiten, Login-Daten, Nutzungsverhalten auf unserer Website.
 * Vertragsdaten: z. B. gekaufte Produkte, Dienstleistungen, Vertragslaufzeiten.
-* Sensible Daten (falls relevant): z. B. Gesundheitsdaten, biometrische Daten zur Identifikation (nur mit ausdrücklicher Einwilligung), amtliche Ausweise.
+* Identifikationsdaten: z. B. amtliche Ausweise. Amtliche Ausweise sind Personendaten, aber keine besonders schützenswerten Personendaten im Sinne von Art. 5 lit. c DSG.
+* Besonders schützenswerte Daten, soweit verarbeitet: biometrische Daten zur Identifikation (nur mit ausdrücklicher Einwilligung).
 
 Die Erhebung dieser Daten erfolgt ausschliesslich zu den in dieser Datenschutzerklärung genannten Zwecken und unter Einhaltung der geltenden datenschutzrechtlichen Vorschriften.
 
@@ -102,22 +105,18 @@ Die DFX AG führt gemäss den Anforderungen des Schweizerischen Datenschutzgeset
 
 Das Verzeichnis wird regelmässig aktualisiert und dokumentiert alle relevanten Verarbeitungsvorgänge, einschliesslich der von Dritten im Auftrag von DFX durchgeführten Verarbeitungen.
 
-Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit an unseren [Support](https://services.dfx.swiss/support) wenden.
+Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit an unseren [Support](https://app.dfx.swiss/support) wenden.
 
 
 ## 3. Profiling und automatisierte Entscheidungsfindung
 
-DFX verwendet Profilingverfahren zur Bereitstellung von Finanzdienstleistungen, insbesondere für:
+DFX setzt Profiling nur in dem Umfang ein, der erforderlich ist, um gesetzliche Pflichten (insbesondere Geldwäscherei- und Sanktionsrecht) zu erfüllen und die Vorgaben unserer Partnerbanken einzuhalten, ohne die die Dienstleistung nicht erbracht werden kann. Bonitätsprüfungen führt DFX nicht durch.
 
-* Bonitätsprüfungen
-* Risikoanalysen
-* Bereitstellung transaktionsbezogener Serviceinformationen
-
-DFX führt keine rein automatisierten Entscheidungsprozesse durch, die rechtsverbindlich sind oder erhebliche Auswirkungen auf betroffene Personen haben. Sollten automatisierte Entscheidungsfindungen oder Profilingverfahren in der Zukunft zum Einsatz kommen, wird DFX sicherstellen, dass diese Verfahren den gesetzlichen Anforderungen des Schweizerischen Datenschutzgesetzes (DSG) entsprechen und betroffene Personen angemessen über den Prozess informiert werden.
+DFX führt keine rein automatisierten Entscheidungsprozesse durch, die rechtsverbindlich sind oder erhebliche Auswirkungen auf betroffene Personen haben.
 
 #### Recht auf Widerspruch
 
-Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, sowie Auskunft über die zugrunde liegende Logik und die Auswirkungen des Profilings auf sie zu verlangen.
+Betroffene Personen haben das Recht, Widerspruch gegen Profiling einzulegen, soweit dem keine gesetzliche Pflicht und keine Vorgabe der Partnerbanken entgegensteht, ohne die die Dienstleistung nicht erbracht werden kann. Sie können Auskunft über die zugrunde liegende Logik und die Auswirkungen des Profilings auf sie verlangen.
 
 
 ## 4. Hosting und Infrastruktur
@@ -134,7 +133,7 @@ Beim Aufruf werden technisch notwendige Daten (insbesondere Ihre IP-Adresse sowi
 Soweit zur Vertragserfüllung oder zur Erfüllung gesetzlicher Pflichten erforderlich, setzen wir folgende Auftragsverarbeiter ein:
 
 * Sumsub (Sum and Substance Ltd., Vereinigtes Königreich) — gesetzlich vorgeschriebene Identitätsprüfung, einschliesslich Ausweisdokumenten und biometrischer Daten. Das Vereinigte Königreich verfügt über einen Angemessenheitsbeschluss (Art. 16 Abs. 1 DSG). Biometrische Daten verarbeiten wir nur mit Ihrer ausdrücklichen Einwilligung (Art. 6 Abs. 7 DSG).
-* Dilisense (Schweiz) — Prüfung gegen Sanktions- und PEP-Listen.
+* Dilisense (Schweiz) — Prüfung gegen Sanktions- und PEP-Listen. Übermittelt werden ausschliesslich Name und Geburtsdatum.
 
 
 ## 6. Allgemeine Hinweise und Pflichtinformationen
@@ -145,24 +144,9 @@ Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer ge
 
 #### Spezifische Aufbewahrungsfristen für personenbezogene Daten
 
-DFX speichert personenbezogene Daten nur so lange, wie es für die jeweiligen Verarbeitungszwecke erforderlich ist oder wie es gesetzliche Vorschriften vorsehen. Nach Ablauf der jeweiligen Fristen werden die Daten gelöscht oder anonymisiert. Nachfolgend finden Sie die spezifischen Aufbewahrungsfristen für die verschiedenen Kategorien personenbezogener Daten:
+DFX speichert personenbezogene Daten, die mit der Geschäftsbeziehung, der Identifikation und den Transaktionen zusammenhängen — einschliesslich technischer Verbindungsdaten wie IP-Adressen — für 10 Jahre nach Beendigung der Geschäftsbeziehung (insbesondere Art. 7 GwG). Eine kürzere Frist für IP-Adressen oder Log-Daten wenden wir nicht an.
 
-1. Vertragsdaten
-Aufbewahrungsfrist: 10 Jahre nach Beendigung des Vertrags.
-
-2. Kommunikationsdaten (z. B. E-Mails, Kontaktformulare)
-Aufbewahrungsfrist: 2 Jahre nach Abschluss der Kommunikation.
-
-3. Finanz- und Zahlungsdaten
-Aufbewahrungsfrist: 10 Jahre nach Abschluss der Transaktion.
-
-4. Nutzungsdaten (z. B. IP-Adressen, Log-Daten)
-Aufbewahrungsfrist: 6 Monate.
-
-5. Sensible Daten (z. B. Gesundheits- oder biometrische Daten, falls erhoben)
-Aufbewahrungsfrist: Nur solange erforderlich, um den angegebenen Zweck zu erfüllen.
-
-6. Bewerbungsunterlagen
+Bewerbungsunterlagen
 Aufbewahrungsfrist: 12 Monate nach Abschluss des Bewerbungsverfahrens.
 
 7. Social-Media-Daten (z.B. für Nutzerprofile)
@@ -231,7 +215,7 @@ Um Datenschutzverletzungen vorzubeugen, setzen wir technische und organisatorisc
 
 ### Kontakt im Falle von Datenschutzverletzungen:
 
-Wenn Sie eine mögliche Datenschutzverletzung bemerken, wenden Sie sich bitte an an unseren [Support](https://services.dfx.swiss/support) wenden.
+Wenn Sie eine mögliche Datenschutzverletzung bemerken, wenden Sie sich bitte an an unseren [Support](https://app.dfx.swiss/support) wenden.
 
 
 ## 8. Datenerfassung auf dieser Website
@@ -240,11 +224,11 @@ Wenn Sie eine mögliche Datenschutzverletzung bemerken, wenden Sie sich bitte an
 
 DFX verwendet Cookies ausschliesslich, um den Betrieb der IT-Systeme und deren Funktionsweise aufrechtzuerhalten. Es werden keine Cookies für das Tracking des Nutzerverhaltens oder ähnliche Zwecke verwendet.
 
-### Anfrage per E-Mail, Telefon oder Telefax
+### Anfrage über das Support-Formular
 
-Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird Ihre Anfrage inklusive aller daraus hervorgehenden personenbezogenen Daten (Name, Anfrage) zum Zwecke der Bearbeitung Ihres Anliegens bei uns gespeichert und verarbeitet. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter.
+Anfragen nehmen wir ausschliesslich über das Formular unter https://app.dfx.swiss/support entgegen. Ihre Anfrage inklusive der daraus hervorgehenden personenbezogenen Daten wird zum Zweck der Bearbeitung gespeichert und verarbeitet. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter.
 
-Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (zum Beispiel nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
+Die über das Formular übermittelten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (zum Beispiel nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
 
 
 ## 9. Analyse-Tools und Werbung
@@ -323,7 +307,7 @@ Details zu deren Umgang mit Ihren personenbezogenen Daten entnehmen Sie der [Dat
 
 ## 11. Datenschutz bei Bewerbungen und im Bewerbungsverfahren
 
-Der für die Bearbeitung Verantwortliche erhebt und verarbeitet die personenbezogenen Daten von Bewerbenden zum Zweck der Durchführung des Bewerbungsverfahrens. Diese Verarbeitung kann auch elektronisch erfolgen, insbesondere wenn Bewerbende zusätzlich relevante Bewerbungsunterlagen per E-Mail (zum Beispiel im PDF-Format oder anderen Dateitypen) übermitteln.
+Der für die Bearbeitung Verantwortliche erhebt und verarbeitet die personenbezogenen Daten von Bewerbenden zum Zweck der Durchführung des Bewerbungsverfahrens. Diese Verarbeitung erfolgt über LinkedIn.
 
 Wenn Sie sich auf ein von uns ausgeschriebenes Stellenangebot bewerben, gelten diese Datenschutzbestimmungen zusätzlich zu unseren anderen Datenschutzbestimmungen, die Ihnen gesondert mitgeteilt wurden oder auf unserer Website verfügbar sind.
 

--- a/src/de/privacy.md
+++ b/src/de/privacy.md
@@ -146,10 +146,10 @@ Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer ge
 
 DFX speichert personenbezogene Daten, die mit der Geschäftsbeziehung, der Identifikation und den Transaktionen zusammenhängen — einschliesslich technischer Verbindungsdaten wie IP-Adressen — für 10 Jahre nach Beendigung der Geschäftsbeziehung (insbesondere Art. 7 GwG). Eine kürzere Frist für IP-Adressen oder Log-Daten wenden wir nicht an.
 
-Bewerbungsunterlagen
+1. Bewerbungsunterlagen
 Aufbewahrungsfrist: 12 Monate nach Abschluss des Bewerbungsverfahrens.
 
-7. Social-Media-Daten (z.B. für Nutzerprofile)
+2. Social-Media-Daten (z.B. für Nutzerprofile)
 Die unmittelbar von uns über die Social Media-Präsenz erfassten Daten werden von unseren Systemen gelöscht, sobald Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt. Gespeicherte Cookies verbleiben auf Ihrem Endgerät, bis Sie sie löschen. Zwingende gesetzliche Bestimmungen – insbesondere Aufbewahrungsfristen – bleiben unberührt.
 
 Auf die Speicherdauer Ihrer Daten, die von den Betreibern der Social Media-Netzwerke zu eigenen Zwecken gespeichert werden, haben wir keinen Einfluss. Für Einzelheiten dazu informieren Sie sich bitte direkt bei den Betreibern der Social Media-Netzwerke (zum Beispiel in deren Datenschutzrichtlinien und -erklärungen, siehe unten).


### PR DESCRIPTION
EN:
German FAQ and privacy policy now match how DFX actually works.
Translations will follow once the German text is approved.

DE:
Die deutsche FAQ und Datenschutzerklärung entsprechen jetzt der tatsächlichen Praxis.
Übersetzungen folgen, wenn der deutsche Text steht.

<details>
<summary>Details</summary>

German only, by design.

- FAQ: Swissquote/Yuh block the rail; DFX cannot change that; apology
- Contact only via https://app.dfx.swiss/support; no email address
- Official IDs are not particularly sensitive data (Art. 5(c) FADP)
- No credit checks
- Profiling only for legal duties and partner-bank requirements
- Dilisense receives name and date of birth only
- Retention: 10 years including IP addresses; no 6-month IP period

</details>