### PR TITLE
019ffaf6 - Align EN/FR/IT privacy and FAQ with German

### DIFF
--- a/src/en/faq.md
+++ b/src/en/faq.md
@@ -4,7 +4,7 @@ This page contains the most frequently asked questions about DFX.swiss.
 
 ## Where can I get support if I have questions?
 DFX offers support in different ways. You can find information about our products and services on our homepage or here in the FAQ. 
-If you have any further questions, please contact our [Support](https://dfx.swiss/help).
+If you have any further questions, please contact our [Support](https://app.dfx.swiss/support).
 
 ## What exactly does the DFX service include?
 DFX is the bridge between the bank and the crypto space, enabling private and corporate customers to buy and sell cryptocurrencies. We are working to expand our offering to as many blockchains as possible. Information about our current offering can be found on our [homepage](https://dfx.swiss/en/).
@@ -21,7 +21,7 @@ DFX only has access to the customer's money during the buying or selling process
 DFX accepts SEPA and SEPA Instant transfers. Whether a transfer is possible depends on whether the customer's bank participates in the SEPA payment area. As a VQF member, DFX is subject to the due diligence obligations of the Swiss Anti-Money Laundering Act (AMLA). Business relationships with persons in jurisdictions classified by the FATF as high-risk jurisdictions cannot be entered into. The current classification can be viewed at https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html.
 
 ## Will I receive an overview of all transactions, including fees, that I made with DFX during the year?
-Yes, you can get a transaction overview of DFX services (buying & selling via fiat and referral rewards). You can also use this for the tax authorities. If you have questions or uncertainties about this, you can simply contact our [Support](https://dfx.swiss/help).
+Yes, you can get a transaction overview of DFX services (buying & selling via fiat and referral rewards). You can also use this for the tax authorities. If you have questions or uncertainties about this, you can simply contact our [Support](https://app.dfx.swiss/support).
 
 ## Is the service also available for corporate customers?
 Yes.
@@ -30,10 +30,10 @@ Yes.
 It can happen that your bank contacts you or has rejected a transfer to our service. This is intended to protect the customer, as fraud or other criminal activities are suspected. In this case, it is advisable to contact your bank so that your bank releases the payment.
 
 ## My bank requires proof of origin for my crypto sales. What do I need to do?
-We are happy to help you and support you with our experts. In a pleasant phone conversation, we go through all relevant points and try to document the origin of the funds in an uncomplicated and simple way. We are happy to help you prepare the payout to your bank account perfectly so that you don't have any problems. Simply contact our [Support](https://dfx.swiss/help) for this.
+We are happy to help you and support you with our experts. In a pleasant phone conversation, we go through all relevant points and try to document the origin of the funds in an uncomplicated and simple way. We are happy to help you prepare the payout to your bank account perfectly so that you don't have any problems. Simply contact our [Support](https://app.dfx.swiss/support) for this.
 
 ### Which currencies are supported by our service?
-We accept CHF and EUR. For transactions exceeding CHF 50,000, alternative currencies are also accepted after consultation. In this case, simply contact our [Support](https://dfx.swiss/help).
+We accept CHF and EUR. For transactions exceeding CHF 50,000, alternative currencies are also accepted after consultation. In this case, simply contact our [Support](https://app.dfx.swiss/support).
 
 ## User-relevant questions & KYC process
 
@@ -127,9 +127,9 @@ No. We want you to convince as many friends and acquaintances as possible of our
 Some banks occasionally block SEPA transfers to crypto service providers. If a transfer is rejected, we recommend contacting your own bank directly to release the payment. Alternatively, another bank or payment service provider can be used for the transfer.
 
 ## Are payments from Swissquote or Yuh supported?
-No. The payment channel between Swissquote or Yuh and DFX is restricted. Transfers from accounts at Swissquote or Yuh can therefore not be processed by us.
+No. The block comes from Swissquote or Yuh, not from DFX. We cannot change this on our side. We apologise to the affected users.
 
-Please use an account at another bank in your own name for your deposit.
+We therefore cannot process transfers from accounts at Swissquote or Yuh. Please use an account at another bank in your own name for your deposit.
 
 If a payment from a Swissquote or Yuh account has already reached us, we will transfer it back to another bank account in your name. Please contact our support for this.
 
@@ -164,7 +164,7 @@ Attention: The videos were created before the introduction of the new DFX fee st
 
 SEPA Instant or standard SEPA can then be used.
 
-If you have questions or uncertainties about this, you can simply contact our [Support](https://dfx.swiss/help).
+If you have questions or uncertainties about this, you can simply contact our [Support](https://app.dfx.swiss/support).
 
 ## How do I integrate the hardware wallet?
 - BitBoxSwiss 
@@ -186,7 +186,7 @@ You can also log in to DFX by manually entering a blockchain address and matchin
 ## What is the status of my transaction? I have not received my crypto assets.
 If you have made a transaction and have questions about this transaction because you have not yet received the crypto assets, you have the following options:
 - If it was a bank transaction, we strongly recommend waiting 2 business days. Bank transactions are usually processed within a few hours, but in extreme cases can also take 3 business days. We therefore recommend waiting 2 business days before starting an investigation.
-- You can also contact [Support](https://dfx.swiss/help) via the website.
+- You can also contact [Support](https://app.dfx.swiss/support) via the website.
 
 ## Which data must be included in a support request?
 For bank transactions, support needs the following information:

--- a/src/en/privacy.md
+++ b/src/en/privacy.md
@@ -23,6 +23,8 @@ Registration Court: Zug, Switzerland
 Website: https://dfx.swiss   
 Electronic contact: https://app.dfx.swiss/support  
 
+We accept inquiries exclusively via this form so that we can fulfil our duties under the Data Protection Act — in particular access, rectification and erasure — correctly. We deliberately do not provide an email address.
+
 
 ## 2. General information on data protection
 
@@ -30,7 +32,7 @@ DFX treats your personal data confidentially and in accordance with the statutor
 
 The use of our website is generally possible without providing personal data. However, if a data subject wishes to use special services of our company via our website, processing of personal data may be necessary. If the processing of personal data is necessary and there is no legal basis for such processing, we obtain the consent of the data subject in an appropriate form after providing appropriate information.  
 
-We would like to point out that, despite the security precautions we have taken, data transmission on the Internet (for example, when communicating by email) may have security vulnerabilities. Complete protection of data against access by third parties is not possible.  
+We would like to point out that, despite the security precautions we have taken, data transmission on the Internet may have security vulnerabilities. Complete protection of data against access by third parties is not possible.  
 
 As the (natural) person concerned, it is in your personal interest to protect the system(s) you use (PC, laptop, etc.) from unauthorized access by third parties, to provide them with adequate password protection and not to disclose the password to third parties. It is recommended to install a commercially available virus protection program and update it regularly.
 
@@ -41,10 +43,11 @@ As part of our business relationships and the use of our services, we process va
 * Contact information: e.g., name, address, phone number, email address.
 * Technical data: e.g., IP addresses, device information, browser type.
 * Payment and financial data: e.g., bank details, credit card data, transaction history, tax returns.
-* Communication data: e.g., contents of emails, contact forms, inquiries.
+* Communication data: e.g., contents of inquiries via the support form.
 * Usage data: e.g., pages visited, login data, usage behavior on our website.
 * Contract data: e.g., purchased products, services, contract terms.
-* Sensitive data (if relevant): e.g., health data, biometric data for identification (only with explicit consent), official identification documents.
+* Identification data: e.g., official identity documents. Official identity documents are personal data, but not particularly sensitive personal data within the meaning of Art. 5(c) FADP.
+* Particularly sensitive data, where processed: biometric data for identification (only with explicit consent).
 
 The collection of this data is carried out exclusively for the purposes stated in this privacy policy and in compliance with applicable data protection regulations.
 
@@ -102,22 +105,18 @@ DFX AG maintains a register of all processing activities involving personal data
 
 The register is regularly updated and documents all relevant processing operations, including processing carried out by third parties on behalf of DFX.
 
-For this and other questions on the subject of data protection, you can contact our [Support](https://services.dfx.swiss/support) at any time.
+For this and other questions on the subject of data protection, you can contact our [Support](https://app.dfx.swiss/support) at any time.
 
 
 ## 3. Profiling and automated decision-making
 
-DFX uses profiling procedures to provide financial services, in particular for:
+DFX uses profiling only to the extent required to fulfil legal duties (in particular anti-money-laundering and sanctions law) and to meet the requirements of our partner banks, without which the service cannot be provided. DFX does not carry out credit checks.
 
-* Credit checks
-* Risk analyses
-* Provision of transaction-related service information
-
-DFX does not carry out purely automated decision-making processes that are legally binding or have significant effects on data subjects. Should automated decision-making or profiling procedures be used in the future, DFX will ensure that these procedures comply with the legal requirements of the Swiss Data Protection Act (DSG) and that data subjects are adequately informed about the process.
+DFX does not carry out purely automated decision-making processes that are legally binding or have significant effects on data subjects.
 
 #### Right to object
 
-Data subjects have the right to object to profiling and to request information about the underlying logic and the effects of profiling on them.
+Data subjects have the right to object to profiling insofar as no legal duty and no partner-bank requirement without which the service cannot be provided stands in the way. They may request information about the underlying logic and the effects of profiling on them.
 
 
 ## 4. Hosting and infrastructure
@@ -134,7 +133,7 @@ When you access them, technically necessary data (in particular your IP address 
 Where required to perform the contract or to comply with legal obligations, we use the following data processors:
 
 * Sumsub (Sum and Substance Ltd., United Kingdom) — legally required identity verification, including identity documents and biometric data. The United Kingdom is covered by an adequacy decision (Art. 16(1) FADP). We process biometric data only with your explicit consent (Art. 6(7) FADP).
-* Dilisense (Switzerland) — screening against sanctions and PEP lists.
+* Dilisense (Switzerland) — screening against sanctions and PEP lists. Only name and date of birth are transmitted.
 
 
 ## 6. General notes and mandatory information
@@ -145,27 +144,12 @@ Unless a more specific storage period has been specified in this privacy policy,
 
 #### Specific retention periods for personal data
 
-DFX stores personal data only as long as it is necessary for the respective processing purposes or as required by legal regulations. After the respective periods have expired, the data will be deleted or anonymized. Below you will find the specific retention periods for the various categories of personal data:
+DFX stores personal data relating to the business relationship, identification and transactions — including technical connection data such as IP addresses — for 10 years after the end of the business relationship (in particular Art. 7 AMLA). We do not apply a shorter period for IP addresses or log data.
 
-1. Contract data
-Retention period: 10 years after termination of the contract.
-
-2. Communication data (e.g., emails, contact forms)
-Retention period: 2 years after completion of communication.
-
-3. Financial and payment data
-Retention period: 10 years after completion of the transaction.
-
-4. Usage data (e.g., IP addresses, log data)
-Retention period: 6 months.
-
-5. Sensitive data (e.g., health or biometric data, if collected)
-Retention period: Only as long as necessary to fulfill the stated purpose.
-
-6. Application documents
+1. Application documents
 Retention period: 12 months after completion of the application process.
 
-7. Social media data (e.g., for user profiles)
+2. Social media data (e.g., for user profiles)
 The data collected directly by us via the social media presence will be deleted from our systems as soon as you ask us to delete it, revoke your consent to storage or the purpose for data storage no longer applies. Stored cookies remain on your end device until you delete them. Mandatory statutory provisions - in particular retention periods - remain unaffected.
 
 We have no influence on the storage period of your data that is stored by the operators of social media networks for their own purposes. For details, please contact the operators of the social media networks directly (e.g., in their privacy policies and statements, see below).
@@ -231,7 +215,7 @@ To prevent data protection violations, we use technical and organizational measu
 
 ### Contact in case of data protection violations:
 
-If you notice a possible data protection violation, please contact our [Support](https://services.dfx.swiss/support).
+If you notice a possible data protection violation, please contact our [Support](https://app.dfx.swiss/support).
 
 
 ## 8. Data collection on this website
@@ -240,11 +224,11 @@ If you notice a possible data protection violation, please contact our [Support]
 
 DFX uses cookies exclusively to maintain the operation of IT systems and their functionality. No cookies are used for tracking user behavior or similar purposes.
 
-### Inquiry by email, telephone or fax
+### Inquiry via the support form
 
-If you contact us by email, telephone or fax, your inquiry including all personal data (name, inquiry) will be stored and processed by us for the purpose of processing your request. We will not pass on this data without your consent.
+We accept inquiries exclusively via the form at https://app.dfx.swiss/support. Your inquiry including the personal data arising from it is stored and processed for the purpose of handling your request. We will not pass on this data without your consent.
 
-The data you send to us via contact requests will remain with us until you ask us to delete it, revoke your consent to storage or the purpose for data storage no longer applies (e.g., after your request has been processed). Mandatory statutory provisions - in particular statutory retention periods - remain unaffected.
+The data submitted via the form remain with us until you ask us to delete them, revoke your consent to storage or the purpose for data storage no longer applies (e.g., after your request has been processed). Mandatory statutory provisions – in particular statutory retention periods – remain unaffected.
 
 
 ## 9. Analysis tools and advertising
@@ -323,7 +307,7 @@ Details on how they handle your personal data can be found in the [LinkedIn Priv
 
 ## 11. Data protection for applications and in the application process
 
-The controller collects and processes the personal data of applicants for the purpose of carrying out the application process. This processing may also take place electronically, in particular if applicants also send relevant application documents by email (e.g., in PDF format or other file types).
+The controller collects and processes the personal data of applicants for the purpose of carrying out the application process. This processing takes place via LinkedIn.
 
 If you apply for a job advertised by us, these data protection provisions apply in addition to our other data protection provisions, which have been communicated to you separately or are available on our website.
 

--- a/src/fr/faq.md
+++ b/src/fr/faq.md
@@ -4,7 +4,7 @@ Cette page contient les questions les plus fréquemment posées sur DFX.swiss.
 
 ## Où puis-je obtenir de l'aide si j'ai des questions ?
 DFX offre un support de différentes manières. Vous pouvez trouver des informations sur nos produits et services sur notre page d'accueil ou ici dans la FAQ. 
-Pour toute autre question, contactez notre [Support](https://dfx.swiss/help).
+Pour toute autre question, contactez notre [Support](https://app.dfx.swiss/support).
 
 ## Qu'est-ce que le service DFX inclut exactement ?
 DFX est le pont entre la banque et l'espace crypto, permettant aux clients privés et professionnels d'acheter et de vendre des cryptomonnaies. Nous travaillons à étendre notre offre à autant de blockchains que possible. Des informations sur notre offre actuelle peuvent être trouvées sur notre [page d'accueil](https://dfx.swiss/fr/).
@@ -21,7 +21,7 @@ DFX n'a accès à l'argent du client que pendant le processus d'achat ou de vent
 DFX accepte les virements SEPA et SEPA Instant. La possibilité d'effectuer un virement dépend de la participation de la banque du client à l'espace de paiement SEPA. En tant que membre VQF, DFX est soumis aux obligations de diligence de la loi suisse sur le blanchiment d'argent (LBA). Les relations d'affaires avec des personnes dans des juridictions classées par le GAFI comme juridictions à haut risque ne peuvent pas être établies. La classification actuelle peut être consultée sur https://www.fatf-gafi.org/fr/pays/listes-noire-et-grise.html.
 
 ## Vais-je recevoir un aperçu de toutes les transactions, y compris les frais, que j'ai effectuées avec DFX pendant l'année ?
-Oui, vous pouvez obtenir un aperçu des transactions des services DFX (achat et vente via fiat et récompenses de parrainage). Vous pouvez également l'utiliser pour les autorités fiscales. Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simplement contacter notre [Support](https://dfx.swiss/help).
+Oui, vous pouvez obtenir un aperçu des transactions des services DFX (achat et vente via fiat et récompenses de parrainage). Vous pouvez également l'utiliser pour les autorités fiscales. Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simplement contacter notre [Support](https://app.dfx.swiss/support).
 
 ## Le service est-il également disponible pour les clients professionnels ?
 Oui.
@@ -30,10 +30,10 @@ Oui.
 Il peut arriver que votre banque vous contacte ou ait rejeté un virement vers notre service. Cela vise à protéger le client, car une fraude ou d'autres activités criminelles sont suspectées. Dans ce cas, il est conseillé de contacter votre banque afin qu'elle libère le paiement.
 
 ## Ma banque exige une preuve d'origine pour mes ventes de crypto. Que dois-je faire ?
-Nous sommes heureux de vous aider et de vous soutenir avec nos experts. Dans une conversation téléphonique agréable, nous passons en revue tous les points pertinents et essayons de documenter l'origine des fonds de manière simple et directe. Nous sommes heureux de vous aider à préparer parfaitement le paiement sur votre compte bancaire afin que vous n'ayez aucun problème. Contactez simplement notre [Support](https://dfx.swiss/help) pour cela.
+Nous sommes heureux de vous aider et de vous soutenir avec nos experts. Dans une conversation téléphonique agréable, nous passons en revue tous les points pertinents et essayons de documenter l'origine des fonds de manière simple et directe. Nous sommes heureux de vous aider à préparer parfaitement le paiement sur votre compte bancaire afin que vous n'ayez aucun problème. Contactez simplement notre [Support](https://app.dfx.swiss/support) pour cela.
 
 ### Quelles devises sont prises en charge par notre service ?
-Nous acceptons CHF et EUR. Pour les transactions dépassant 50 000 CHF, des devises alternatives sont également acceptées après consultation. Dans ce cas, contactez simplement notre [Support](https://dfx.swiss/help).
+Nous acceptons CHF et EUR. Pour les transactions dépassant 50 000 CHF, des devises alternatives sont également acceptées après consultation. Dans ce cas, contactez simplement notre [Support](https://app.dfx.swiss/support).
 
 ## Questions pertinentes pour l'utilisateur et processus KYC
 
@@ -127,9 +127,9 @@ Non. Nous voulons que vous convainquiez autant d'amis et de connaissances que po
 Certaines banques bloquent occasionnellement les virements SEPA vers les fournisseurs de services crypto. Si un virement est rejeté, nous recommandons de contacter directement votre propre banque pour libérer le paiement. Alternativement, une autre banque ou un autre prestataire de services de paiement peut être utilisé pour le virement.
 
 ## Les paiements depuis Swissquote ou Yuh sont-ils pris en charge ?
-Non. Le canal de paiement entre Swissquote ou Yuh et DFX est restreint. Les virements provenant de comptes Swissquote ou Yuh ne peuvent donc pas être traités par nos soins.
+Non. Le blocage vient de Swissquote ou Yuh, pas de DFX. Nous ne pouvons pas le modifier de notre côté. Nous présentons nos excuses aux utilisateurs concernés.
 
-Veuillez utiliser pour votre dépôt un compte à votre nom auprès d'une autre banque.
+Nous ne pouvons donc pas traiter les virements provenant de comptes Swissquote ou Yuh. Veuillez utiliser pour votre dépôt un compte à votre nom auprès d'une autre banque.
 
 Si un paiement provenant d'un compte Swissquote ou Yuh nous est déjà parvenu, nous le reversons sur un autre compte bancaire à votre nom. Veuillez contacter notre support à ce sujet.
 
@@ -164,7 +164,7 @@ Attention : Les vidéos ont été créées avant l'introduction de la nouvelle s
 
 SEPA Instant ou SEPA standard peut ensuite être utilisé.
 
-Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simplement contacter notre [Support](https://dfx.swiss/help).
+Si vous avez des questions ou des incertitudes à ce sujet, vous pouvez simplement contacter notre [Support](https://app.dfx.swiss/support).
 
 ## Comment intégrer le portefeuille matériel ?
 - BitBoxSwiss 
@@ -186,7 +186,7 @@ Vous pouvez également vous connecter à DFX en saisissant manuellement une adre
 ## Quel est le statut de ma transaction ? Je n'ai pas reçu mes actifs crypto.
 Si vous avez effectué une transaction et avez des questions sur cette transaction parce que vous n'avez pas encore reçu les actifs crypto, vous avez les options suivantes :
 - S'il s'agissait d'une transaction bancaire, nous recommandons fortement d'attendre 2 jours ouvrables. Les transactions bancaires sont généralement traitées en quelques heures, mais dans des cas extrêmes peuvent également prendre 3 jours ouvrables. Nous recommandons donc d'attendre 2 jours ouvrables avant de commencer une enquête.
-- Vous pouvez également contacter le [Support](https://dfx.swiss/help) via le site Web.
+- Vous pouvez également contacter le [Support](https://app.dfx.swiss/support) via le site Web.
 
 ## Quelles données doivent être incluses dans une demande de support ?
 Pour les transactions bancaires, le support a besoin des informations suivantes :

--- a/src/fr/privacy.md
+++ b/src/fr/privacy.md
@@ -23,6 +23,8 @@ Tribunal d'enregistrement : Zug, Suisse
 Site Internet : https://dfx.swiss
 Contact électronique : https://app.dfx.swiss/support
 
+Nous n'acceptons les demandes que via ce formulaire, afin de pouvoir remplir correctement nos obligations issues de la loi sur la protection des données — notamment l'accès, la rectification et l'effacement. Nous ne mettons volontairement pas d'adresse e-mail à disposition.
+
 
 ## 2. Informations générales sur la protection des données
 
@@ -30,7 +32,7 @@ DFX traite vos données personnelles de manière confidentielle et conformément
 
 L'utilisation de notre site Internet est généralement possible sans fournir de données personnelles. Toutefois, si une personne concernée souhaite utiliser des services spéciaux de notre société via notre site Internet, un traitement de données personnelles peut être nécessaire. Si le traitement des données personnelles est nécessaire et qu'il n'existe aucune base légale pour un tel traitement, nous obtenons le consentement de la personne concernée sous une forme appropriée après avoir fourni les informations appropriées.
 
-Nous attirons votre attention sur le fait que, malgré les mesures de sécurité que nous avons prises, la transmission de données sur Internet (par exemple lors de la communication par courrier électronique) peut présenter des failles de sécurité. Une protection complète des données contre l'accès par des tiers n'est pas possible.
+Nous attirons votre attention sur le fait que, malgré les mesures de sécurité que nous avons prises, la transmission de données sur Internet peut présenter des failles de sécurité. Une protection complète des données contre l'accès par des tiers n'est pas possible.
 
 En tant que personne (physique) concernée, il est dans votre intérêt personnel de protéger le(s) système(s) que vous utilisez (PC, ordinateur portable, etc.) contre tout accès non autorisé par des tiers, de leur fournir une protection par mot de passe adéquate et de ne pas divulguer le mot de passe à des tiers. Il est recommandé d'installer un programme antivirus disponible dans le commerce et de le mettre à jour régulièrement.
 
@@ -41,10 +43,11 @@ Dans le cadre de nos relations commerciales et de l’utilisation de nos service
 * Coordonnées : par exemple, nom, adresse, numéro de téléphone, adresse e-mail.
 * Données techniques : par exemple, adresses IP, informations sur l'appareil, type de navigateur.
 * Données de paiement et financières : par exemple, coordonnées bancaires, données de carte de crédit, historique des transactions, déclarations de revenus.
-* Données de communication : par exemple, contenu des e-mails, formulaires de contact, demandes de renseignements.
+* Données de communication : par exemple, contenu des demandes via le formulaire de support.
 * Données d'utilisation : par exemple, pages visitées, données de connexion, comportement d'utilisation sur notre site Internet.
 * Données contractuelles : par exemple, produits achetés, services, conditions contractuelles.
-* Données sensibles (le cas échéant) : par exemple, données de santé, données biométriques d'identification (uniquement avec consentement explicite), documents d'identification officiels.
+* Données d'identification : par exemple, pièces d'identité officielles. Les pièces d'identité officielles sont des données personnelles, mais pas des données personnelles particulièrement sensibles au sens de l'art. 5 let. c LPD.
+* Données particulièrement sensibles, lorsqu'elles sont traitées : données biométriques d'identification (uniquement avec consentement exprès).
 
 La collecte de ces données est effectuée exclusivement aux fins indiquées dans la présente politique de confidentialité et dans le respect de la réglementation applicable en matière de protection des données.
 
@@ -71,7 +74,7 @@ Le traitement de vos données personnelles est effectué notamment pour les fina
 * Communication client : cela comprend la réponse aux demandes de renseignements, l'assistance et la transmission d'informations importantes sur nos services.
 * Communication sur les services : si vous avez consenti, nous utilisons vos données pour vous fournir des informations pertinentes sur nos services.
 * Sécurité informatique et prévention de la fraude : Pour protéger nos systèmes informatiques et détecter et prévenir les accès non autorisés, les cyberattaques ou autres activités frauduleuses.
-* Respect des obligations légales et réglementaires : Cela inclut par exemple le respect des obligations du droit fiscal ou commercial ainsi que des exigences de la loi Informatique et Libertés.
+* Respect des obligations légales et réglementaires : Cela inclut par exemple le respect des obligations du droit fiscal ou commercial ainsi que des exigences de la loi sur la protection des données (LPD).
 
 ### Protection des données grâce à une conception technique et des paramètres par défaut respectueux de la vie privée
 
@@ -102,22 +105,18 @@ DFX AG tient un registre de toutes les activités de traitement impliquant des d
 
 Le registre est régulièrement mis à jour et documente toutes les opérations de traitement pertinentes, y compris les traitements effectués par des tiers pour le compte de DFX.
 
-Pour cette question et d'autres questions relatives à la protection des données, vous pouvez à tout moment contacter notre [Support](https://services.dfx.swiss/support).
+Pour cette question et d'autres questions relatives à la protection des données, vous pouvez à tout moment contacter notre [Support](https://app.dfx.swiss/support).
 
 
 ## 3. Profilage et prise de décision automatisée
 
-DFX utilise des procédures de profilage pour fournir des services financiers, notamment pour :
+DFX n'utilise le profilage que dans la mesure nécessaire pour remplir des obligations légales (en particulier le droit en matière de blanchiment d'argent et de sanctions) et pour respecter les exigences de nos banques partenaires, sans lesquelles le service ne peut pas être fourni. DFX n'effectue pas de vérifications de crédit.
 
-* Vérifications de crédit
-* Analyses de risques
-* Fourniture d'informations sur les services liés aux transactions
-
-DFX ne met pas en œuvre de processus décisionnels purement automatisés, juridiquement contraignants ou ayant des effets significatifs sur les personnes concernées. Si des procédures de prise de décision ou de profilage automatisées sont utilisées à l'avenir, DFX veillera à ce que ces procédures soient conformes aux exigences légales de la loi suisse sur la protection des données (DSG) et à ce que les personnes concernées soient correctement informées du processus.
+DFX ne met pas en œuvre de processus décisionnels purement automatisés, juridiquement contraignants ou ayant des effets significatifs sur les personnes concernées.
 
 #### Droit d'opposition
 
-Les personnes concernées ont le droit de s'opposer au profilage et de demander des informations sur la logique sous-jacente et les effets du profilage sur elles.
+Les personnes concernées ont le droit de s'opposer au profilage, dans la mesure où aucune obligation légale et aucune exigence des banques partenaires sans laquelle le service ne peut pas être fourni ne s'y oppose. Elles peuvent demander des informations sur la logique sous-jacente et les effets du profilage sur elles.
 
 
 ## 4. Hébergement et infrastructure
@@ -134,7 +133,7 @@ Lors de l'accès, des données techniquement nécessaires (notamment votre adres
 Lorsque cela est nécessaire à l'exécution du contrat ou au respect d'obligations légales, nous faisons appel aux sous-traitants suivants :
 
 * Sumsub (Sum and Substance Ltd., Royaume-Uni) — vérification d'identité légalement requise, y compris les documents d'identité et les données biométriques. Le Royaume-Uni bénéficie d'une décision d'adéquation (art. 16 al. 1 LPD). Nous ne traitons des données biométriques qu'avec votre consentement exprès (art. 6 al. 7 LPD).
-* Dilisense (Suisse) — contrôle des listes de sanctions et PEP.
+* Dilisense (Suisse) — contrôle des listes de sanctions et PEP. Seuls le nom et la date de naissance sont transmis.
 
 
 ## 6. Notes générales et informations obligatoires
@@ -145,27 +144,12 @@ Sauf si une période de conservation plus spécifique a été spécifiée dans l
 
 #### Délais de conservation spécifiques des données personnelles
 
-DFX conserve les données personnelles uniquement aussi longtemps que cela est nécessaire aux fins de traitement respectives ou si les réglementations légales l'exigent. Après l'expiration des délais respectifs, les données seront supprimées ou anonymisées. Vous trouverez ci-dessous les durées de conservation spécifiques aux différentes catégories de données personnelles :
+DFX conserve les données personnelles liées à la relation d'affaires, à l'identification et aux transactions — y compris les données techniques de connexion telles que les adresses IP — pendant 10 ans après la fin de la relation d'affaires (en particulier art. 7 LBA). Nous n'appliquons pas de délai plus court pour les adresses IP ou les données de journal.
 
-1. Données du contrat
-Durée de conservation : 10 ans après la résiliation du contrat.
-
-2. Données de communication (par exemple, e-mails, formulaires de contact)
-Durée de conservation : 2 ans après la fin de la communication.
-
-3. Données financières et de paiement
-Durée de conservation : 10 ans après la réalisation de la transaction.
-
-4. Données d'utilisation (par exemple, adresses IP, données de journal)
-Durée de conservation : 6 mois.
-
-5. Données sensibles (par exemple, données de santé ou biométriques, si elles sont collectées)
-Durée de conservation : uniquement aussi longtemps que nécessaire pour atteindre l'objectif déclaré.
-
-6. Documents de candidature
+1. Documents de candidature
 Durée de conservation : 12 mois après la fin du processus de candidature.
 
-7. Données des réseaux sociaux (par exemple, pour les profils d'utilisateurs)
+2. Données des réseaux sociaux (par exemple, pour les profils d'utilisateurs)
 Les données que nous collectons directement via la présence sur les réseaux sociaux seront supprimées de nos systèmes dès que vous nous demandez de les supprimer, que vous révoquez votre consentement au stockage ou que la finalité du stockage des données n'est plus applicable. Les cookies stockés restent sur votre appareil final jusqu'à ce que vous les supprimiez. Les dispositions légales obligatoires - en particulier les délais de conservation - restent inchangées.
 
 Nous n'avons aucune influence sur la durée de conservation de vos données stockées par les opérateurs des réseaux sociaux à leurs propres fins. Pour plus de détails, veuillez contacter directement les opérateurs des réseaux sociaux (par exemple, dans leurs politiques et déclarations de confidentialité, voir ci-dessous).
@@ -231,7 +215,7 @@ Pour prévenir les violations de la protection des données, nous utilisons des 
 
 ### Contact en cas de violation de la protection des données :
 
-Si vous constatez une éventuelle violation de la protection des données, veuillez contacter notre [Support](https://services.dfx.swiss/support).
+Si vous constatez une éventuelle violation de la protection des données, veuillez contacter notre [Support](https://app.dfx.swiss/support).
 
 
 ## 8. Collecte de données sur ce site Web
@@ -240,11 +224,11 @@ Si vous constatez une éventuelle violation de la protection des données, veuil
 
 DFX utilise des cookies exclusivement pour maintenir le fonctionnement des systèmes informatiques et leurs fonctionnalités. Aucun cookie n'est utilisé pour suivre le comportement des utilisateurs ou à des fins similaires.
 
-### Demande par email, téléphone ou fax
+### Demande via le formulaire de support
 
-Si vous nous contactez par e-mail, téléphone ou fax, votre demande, y compris toutes les données personnelles (nom, demande), sera stockée et traitée par nos soins dans le but de traiter votre demande. Nous ne transmettrons pas ces données sans votre consentement.
+Nous n'acceptons les demandes que via le formulaire sous https://app.dfx.swiss/support. Votre demande, y compris les données personnelles qui en découlent, est stockée et traitée aux fins de son traitement. Nous ne transmettrons pas ces données sans votre consentement.
 
-Les données que vous nous envoyez via les demandes de contact resteront chez nous jusqu'à ce que vous nous demandiez de les supprimer, que vous révoquiez votre consentement au stockage ou que la finalité du stockage des données ne s'applique plus (par exemple, après le traitement de votre demande). Les dispositions légales obligatoires - en particulier les délais de conservation légaux - restent inchangées.
+Les données transmises via le formulaire restent chez nous jusqu'à ce que vous nous demandiez de les supprimer, que vous révoquiez votre consentement au stockage ou que la finalité du stockage des données ne s'applique plus (par exemple, après le traitement de votre demande). Les dispositions légales obligatoires – en particulier les délais de conservation légaux – restent inchangées.
 
 
 ## 9. Outils d'analyse et publicité
@@ -323,7 +307,7 @@ Des détails sur la manière dont ils traitent vos données personnelles peuvent
 
 ## 11. Protection des données pour les candidatures et pendant le processus de candidature
 
-Le responsable du traitement collecte et traite les données personnelles des candidats dans le but de mener à bien la procédure de candidature. Ce traitement peut également avoir lieu par voie électronique, en particulier si les candidats envoient également les documents de candidature pertinents par courrier électronique (par exemple au format PDF ou dans d'autres types de fichiers).
+Le responsable du traitement collecte et traite les données personnelles des candidats dans le but de mener à bien la procédure de candidature. Ce traitement s'effectue via LinkedIn.
 
 Si vous postulez à un emploi que nous proposons, ces dispositions sur la protection des données s'appliquent en plus de nos autres dispositions sur la protection des données, qui vous ont été communiquées séparément ou sont disponibles sur notre site Internet.
 

--- a/src/it/faq.md
+++ b/src/it/faq.md
@@ -4,7 +4,7 @@ Questa pagina contiene le domande più frequenti su DFX.swiss.
 
 ## Dove posso ottenere supporto se ho domande?
 DFX offre supporto in diversi modi. Puoi trovare informazioni sui nostri prodotti e servizi sulla nostra homepage o qui nelle FAQ. 
-Per ulteriori domande, contatta il nostro [Supporto](https://dfx.swiss/help).
+Per ulteriori domande, contatta il nostro [Supporto](https://app.dfx.swiss/support).
 
 ## Cosa include esattamente il servizio DFX?
 DFX è il ponte tra la banca e lo spazio crypto, consentendo ai clienti privati e aziendali di acquistare e vendere criptovalute. Stiamo lavorando per espandere la nostra offerta a quante più blockchain possibile. Informazioni sulla nostra offerta attuale possono essere trovate sulla nostra [homepage](https://dfx.swiss/it/).
@@ -21,7 +21,7 @@ DFX ha accesso al denaro del cliente solo durante il processo di acquisto o vend
 DFX accetta bonifici SEPA e SEPA Instant. La possibilità di effettuare un bonifico dipende dalla partecipazione della banca del cliente all'area di pagamento SEPA. In quanto membro VQF, DFX è soggetto agli obblighi di diligenza della legge svizzera sul riciclaggio di denaro (LRD). Non possono essere stabilite relazioni commerciali con persone in giurisdizioni classificate dal GAFI come giurisdizioni ad alto rischio. La classificazione attuale può essere visualizzata su https://www.fatf-gafi.org/it/paesi/liste-nera-e-grigia.html.
 
 ## Riceverò una panoramica di tutte le transazioni, comprese le commissioni, che ho effettuato con DFX durante l'anno?
-Sì, puoi ottenere una panoramica delle transazioni dei servizi DFX (acquisto e vendita tramite fiat e ricompense di referral). Puoi anche utilizzarla per le autorità fiscali. Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [Supporto](https://dfx.swiss/help).
+Sì, puoi ottenere una panoramica delle transazioni dei servizi DFX (acquisto e vendita tramite fiat e ricompense di referral). Puoi anche utilizzarla per le autorità fiscali. Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [Supporto](https://app.dfx.swiss/support).
 
 ## Il servizio è disponibile anche per i clienti aziendali?
 Sì.
@@ -30,10 +30,10 @@ Sì.
 Può succedere che la tua banca ti contatti o abbia rifiutato un bonifico al nostro servizio. Questo è inteso a proteggere il cliente, poiché si sospettano frodi o altre attività criminali. In questo caso, è consigliabile contattare la tua banca in modo che rilasci il pagamento.
 
 ## La mia banca richiede una prova di origine per le mie vendite di crypto. Cosa devo fare?
-Siamo felici di aiutarti e supportarti con i nostri esperti. In una piacevole conversazione telefonica, esaminiamo tutti i punti rilevanti e cerchiamo di documentare l'origine dei fondi in modo semplice e diretto. Siamo felici di aiutarti a preparare perfettamente il pagamento sul tuo conto bancario in modo che tu non abbia problemi. Contatta semplicemente il nostro [Supporto](https://dfx.swiss/help) per questo.
+Siamo felici di aiutarti e supportarti con i nostri esperti. In una piacevole conversazione telefonica, esaminiamo tutti i punti rilevanti e cerchiamo di documentare l'origine dei fondi in modo semplice e diretto. Siamo felici di aiutarti a preparare perfettamente il pagamento sul tuo conto bancario in modo che tu non abbia problemi. Contatta semplicemente il nostro [Supporto](https://app.dfx.swiss/support) per questo.
 
 ### Quali valute sono supportate dal nostro servizio?
-Accettiamo CHF ed EUR. Per transazioni superiori a 50.000 CHF, sono accettate anche valute alternative dopo consultazione. In questo caso, contatta semplicemente il nostro [Supporto](https://dfx.swiss/help).
+Accettiamo CHF ed EUR. Per transazioni superiori a 50.000 CHF, sono accettate anche valute alternative dopo consultazione. In questo caso, contatta semplicemente il nostro [Supporto](https://app.dfx.swiss/support).
 
 ## Domande rilevanti per l'utente e processo KYC
 
@@ -127,9 +127,9 @@ No. Vogliamo che tu convinca quanti più amici e conoscenti possibile del nostro
 Alcune banche occasionalmente bloccano i bonifici SEPA ai fornitori di servizi crypto. Se un bonifico viene rifiutato, raccomandiamo di contattare direttamente la propria banca per rilasciare il pagamento. In alternativa, può essere utilizzata un'altra banca o un altro fornitore di servizi di pagamento per il bonifico.
 
 ## I pagamenti da Swissquote o Yuh sono supportati?
-No. Il canale di pagamento tra Swissquote o Yuh e DFX è limitato. I bonifici da conti presso Swissquote o Yuh non possono quindi essere elaborati da noi.
+No. Il blocco viene da Swissquote o Yuh, non da DFX. Non possiamo modificarlo da parte nostra. Chiediamo scusa agli utenti interessati.
 
-Per il tuo deposito, utilizza un conto a tuo nome presso un'altra banca.
+Pertanto non possiamo elaborare i bonifici provenienti da conti Swissquote o Yuh. Per il tuo deposito, utilizza un conto a tuo nome presso un'altra banca.
 
 Se un pagamento da un conto Swissquote o Yuh è già arrivato presso di noi, lo ritrasferiamo su un altro conto bancario a tuo nome. Contatta il nostro supporto a riguardo.
 
@@ -164,7 +164,7 @@ Attenzione: I video sono stati creati prima dell'introduzione della nuova strutt
 
 SEPA Instant o SEPA standard può quindi essere utilizzato.
 
-Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [Supporto](https://dfx.swiss/help).
+Se hai domande o incertezze su questo, puoi semplicemente contattare il nostro [Supporto](https://app.dfx.swiss/support).
 
 ## Come integro il portafoglio hardware?
 - BitBoxSwiss 
@@ -186,7 +186,7 @@ Puoi anche accedere a DFX inserendo manualmente un indirizzo blockchain e una fi
 ## Qual è lo stato della mia transazione? Non ho ricevuto i miei asset crypto.
 Se hai effettuato una transazione e hai domande su questa transazione perché non hai ancora ricevuto gli asset crypto, hai le seguenti opzioni:
 - Se si trattava di una transazione bancaria, raccomandiamo vivamente di attendere 2 giorni lavorativi. Le transazioni bancarie vengono solitamente elaborate entro poche ore, ma in casi estremi possono anche richiedere 3 giorni lavorativi. Raccomandiamo quindi di attendere 2 giorni lavorativi prima di avviare un'indagine.
-- Puoi anche contattare il [Supporto](https://dfx.swiss/help) tramite il sito web.
+- Puoi anche contattare il [Supporto](https://app.dfx.swiss/support) tramite il sito web.
 
 ## Quali dati devono essere inclusi in una richiesta di supporto?
 Per le transazioni bancarie, il supporto necessita delle seguenti informazioni:

--- a/src/it/privacy.md
+++ b/src/it/privacy.md
@@ -23,6 +23,8 @@ Tribunale di registrazione: Zugo, Svizzera
 Sito web: https://dfx.swiss   
 Contatto elettronico: https://app.dfx.swiss/support  
 
+Accettiamo le richieste esclusivamente tramite questo modulo, così da poter adempiere correttamente agli obblighi della legge sulla protezione dei dati — in particolare accesso, rettifica e cancellazione. Consapevolmente non mettiamo a disposizione un indirizzo e-mail.
+
 
 ##2. Informazioni generali sulla protezione dei dati
 
@@ -30,7 +32,7 @@ DFX tratta i tuoi dati personali in modo confidenziale e in conformità con le n
 
 L'utilizzo del nostro sito web è generalmente possibile senza fornire dati personali. Tuttavia, se l’interessato desidera utilizzare servizi speciali della nostra azienda tramite il nostro sito web, potrebbe essere necessario il trattamento dei dati personali. Se il trattamento dei dati personali è necessario e non esiste una base giuridica per tale trattamento, otteniamo il consenso dell'interessato in forma adeguata dopo aver fornito idonea informativa.  
 
-Desideriamo sottolineare che, nonostante le precauzioni di sicurezza da noi adottate, la trasmissione di dati su Internet (ad esempio durante la comunicazione via e-mail) può presentare vulnerabilità di sicurezza. Non è possibile una protezione completa dei dati dall'accesso di terzi.  
+Desideriamo sottolineare che, nonostante le precauzioni di sicurezza da noi adottate, la trasmissione di dati su Internet può presentare vulnerabilità di sicurezza. Non è possibile una protezione completa dei dati dall'accesso di terzi.  
 
 In qualità di persona (fisica) interessata, è nel tuo interesse personale proteggere il/i sistema/i che utilizzi (PC, laptop, ecc.) da accessi non autorizzati da parte di terzi, fornire loro un'adeguata protezione con password e non divulgare la password a terzi. Si consiglia di installare un programma di protezione antivirus disponibile in commercio e di aggiornarlo regolarmente.
 
@@ -41,10 +43,11 @@ Nell’ambito dei nostri rapporti commerciali e dell’utilizzo dei nostri servi
 * Informazioni di contatto: ad esempio nome, indirizzo, numero di telefono, indirizzo e-mail.
 * Dati tecnici: ad esempio indirizzi IP, informazioni sul dispositivo, tipo di browser.
 * Dati finanziari e di pagamento: ad esempio, dettagli bancari, dati della carta di credito, cronologia delle transazioni, dichiarazioni dei redditi.
-*Dati di comunicazione: ad esempio contenuto di e-mail, moduli di contatto, richieste.
+* Dati di comunicazione: ad esempio contenuto delle richieste tramite il modulo di supporto.
 * Dati di utilizzo: ad esempio pagine visitate, dati di accesso, comportamento di utilizzo sul nostro sito web.
 * Dati contrattuali: ad esempio prodotti acquistati, servizi, condizioni contrattuali.
-*Dati sensibili (se rilevanti): ad es. dati sanitari, dati biometrici per l'identificazione (solo con esplicito consenso), documenti di identificazione ufficiali.
+* Dati di identificazione: ad esempio documenti d'identità ufficiali. I documenti d'identità ufficiali sono dati personali, ma non dati personali particolarmente sensibili ai sensi dell'art. 5 lett. c LPD.
+* Dati particolarmente sensibili, se trattati: dati biometrici per l'identificazione (solo con consenso esplicito).
 
 La raccolta di questi dati viene effettuata esclusivamente per gli scopi indicati nella presente informativa sulla privacy e nel rispetto delle normative applicabili sulla protezione dei dati.
 
@@ -102,22 +105,18 @@ DFX AG mantiene un registro di tutte le attività di trattamento che coinvolgono
 
 Il registro viene regolarmente aggiornato e documenta tutte le operazioni di trattamento rilevanti, compreso il trattamento effettuato da terzi per conto di DFX.
 
-Per questa e altre domande sul tema della protezione dei dati potete contattare in qualsiasi momento il nostro [Supporto](https://services.dfx.swiss/support).
+Per questa e altre domande sul tema della protezione dei dati potete contattare in qualsiasi momento il nostro [Supporto](https://app.dfx.swiss/support).
 
 
 ## 3. Profilazione e processo decisionale automatizzato
 
-DFX utilizza procedure di profilazione per fornire servizi finanziari, in particolare per:
+DFX utilizza la profilazione solo nella misura necessaria per adempiere obblighi di legge (in particolare il diritto in materia di riciclaggio e sanzioni) e per rispettare i requisiti delle nostre banche partner, senza i quali il servizio non può essere prestato. DFX non effettua controlli del credito.
 
-*Controlli del credito
-* Analisi dei rischi
-* Fornitura di informazioni sui servizi relativi alle transazioni
-
-DFX non esegue processi decisionali puramente automatizzati che sono giuridicamente vincolanti o hanno effetti significativi sugli interessati. Qualora in futuro venissero utilizzate procedure decisionali o di profilazione automatizzate, DFX garantirà che tali procedure siano conformi ai requisiti legali della legge svizzera sulla protezione dei dati (DSG) e che gli interessati siano adeguatamente informati sul processo.
+DFX non esegue processi decisionali puramente automatizzati che sono giuridicamente vincolanti o hanno effetti significativi sugli interessati.
 
 #### Diritto di opposizione
 
-Gli interessati hanno il diritto di opporsi alla profilazione e di chiedere informazioni sulla logica sottostante e sugli effetti della profilazione su di loro.
+Gli interessati hanno il diritto di opporsi alla profilazione, purché non osti un obbligo di legge o un requisito delle banche partner senza il quale il servizio non può essere prestato. Possono chiedere informazioni sulla logica sottostante e sugli effetti della profilazione su di loro.
 
 
 ## 4. Hosting e infrastruttura
@@ -134,7 +133,7 @@ All'accesso, i dati tecnicamente necessari (in particolare l'indirizzo IP e i me
 Ove necessario per l'esecuzione del contratto o per adempiere obblighi di legge, utilizziamo i seguenti responsabili del trattamento:
 
 * Sumsub (Sum and Substance Ltd., Regno Unito) — verifica dell'identità prescritta dalla legge, compresi documenti d'identità e dati biometrici. Il Regno Unito dispone di una decisione di adeguatezza (art. 16 cpv. 1 LPD). Trattiamo i dati biometrici solo con il vostro consenso esplicito (art. 6 cpv. 7 LPD).
-* Dilisense (Svizzera) — controllo delle liste di sanzioni e PEP.
+* Dilisense (Svizzera) — controllo delle liste di sanzioni e PEP. Vengono trasmessi esclusivamente nome e data di nascita.
 
 
 ## 6. Note generali e informazioni obbligatorie
@@ -145,27 +144,12 @@ A meno che nella presente informativa sulla privacy non sia specificato un perio
 
 #### Periodi specifici di conservazione dei dati personali
 
-DFX memorizza i dati personali solo per il tempo necessario ai rispettivi scopi di trattamento o come richiesto dalle norme legali. Decorsi i rispettivi termini, i dati verranno cancellati o resi anonimi. Di seguito troverete i periodi di conservazione specifici per le varie categorie di dati personali:
+DFX conserva i dati personali relativi al rapporto commerciale, all'identificazione e alle transazioni — compresi i dati tecnici di connessione come gli indirizzi IP — per 10 anni dalla cessazione del rapporto commerciale (in particolare art. 7 LRD). Non applichiamo un termine più breve per indirizzi IP o dati di registro.
 
-1. Dati contrattuali
-Periodo di conservazione: 10 anni dalla risoluzione del contratto.
-
-2. Dati di comunicazione (es. email, moduli di contatto)
-Periodo di conservazione: 2 anni dal completamento della comunicazione.
-
-3. Dati finanziari e di pagamento
-Periodo di conservazione: 10 anni dal perfezionamento dell'operazione.
-
-4. Dati di utilizzo (ad esempio indirizzi IP, dati di registro)
-Periodo di conservazione: 6 mesi.
-
-5. Dati sensibili (ad esempio, dati sanitari o biometrici, se raccolti)
-Periodo di conservazione: solo il tempo necessario per adempiere allo scopo dichiarato.
-
-6. Documenti per la domanda
+1. Documenti per la domanda
 Periodo di conservazione: 12 mesi dal completamento del processo di candidatura.
 
-7. Dati dei social media (ad esempio, per i profili utente)
+2. Dati dei social media (ad esempio, per i profili utente)
 I dati da noi raccolti direttamente tramite la presenza sui social media verranno cancellati dai nostri sistemi non appena ci chiederete di cancellarli, revocherete il vostro consenso alla memorizzazione o lo scopo della memorizzazione dei dati non sarà più applicabile. I cookie memorizzati rimangono sul tuo dispositivo finché non li elimini. Le disposizioni di legge obbligatorie, in particolare i termini di conservazione, rimangono inalterate.
 
 Non abbiamo alcuna influenza sulla durata di conservazione dei vostri dati che vengono archiviati dagli operatori delle reti di social media per i propri scopi. Per i dettagli si prega di contattare direttamente gli operatori dei social network (ad esempio, nelle loro informative e dichiarazioni sulla privacy, vedere di seguito).
@@ -231,7 +215,7 @@ Per prevenire violazioni della protezione dei dati, utilizziamo misure tecniche 
 
 ### Contatto in caso di violazioni della protezione dei dati:
 
-Se noti una possibile violazione della protezione dei dati, contatta il nostro [Supporto](https://services.dfx.swiss/support).
+Se noti una possibile violazione della protezione dei dati, contatta il nostro [Supporto](https://app.dfx.swiss/support).
 
 
 ## 8. Raccolta dati su questo sito
@@ -240,11 +224,11 @@ Se noti una possibile violazione della protezione dei dati, contatta il nostro [
 
 DFX utilizza i cookie esclusivamente per mantenere il funzionamento dei sistemi IT e la loro funzionalità. Non vengono utilizzati cookie per tracciare il comportamento dell'utente o scopi simili.
 
-### Richiesta via e-mail, telefono o fax
+### Richiesta tramite il modulo di supporto
 
-Se ci contatti via e-mail, telefono o fax, la tua richiesta, compresi tutti i dati personali (nome, richiesta) verrà archiviata ed elaborata da noi allo scopo di elaborare la tua richiesta. Non trasmetteremo questi dati senza il tuo consenso.
+Accettiamo le richieste esclusivamente tramite il modulo all'indirizzo https://app.dfx.swiss/support. La richiesta, compresi i dati personali che ne derivano, viene archiviata ed elaborata allo scopo di trattarla. Non trasmetteremo questi dati senza il tuo consenso.
 
-I dati che ci invii tramite richieste di contatto rimarranno con noi fino a quando non ci chiederai di cancellarli, revocherai il tuo consenso alla memorizzazione o lo scopo della memorizzazione dei dati non sarà più applicabile (ad esempio, dopo che la tua richiesta è stata elaborata). Le disposizioni di legge obbligatorie, in particolare i termini di conservazione previsti dalla legge, rimangono inalterate.
+I dati trasmessi tramite il modulo restano presso di noi fino a quando non ci chiederai di cancellarli, revocherai il consenso alla memorizzazione o lo scopo della memorizzazione non sarà più applicabile (ad esempio dopo la trattazione della richiesta). Le disposizioni di legge obbligatorie – in particolare i termini di conservazione previsti dalla legge – rimangono inalterate.
 
 
 ## 9. Strumenti di analisi e pubblicità
@@ -323,7 +307,7 @@ I dettagli su come gestiscono i tuoi dati personali possono essere trovati nella
 
 ## 11. Protezione dei dati durante le candidature e nel processo di candidatura
 
-Il responsabile del trattamento raccoglie e tratta i dati personali dei candidati allo scopo di eseguire il processo di candidatura. Questo trattamento può avvenire anche elettronicamente, in particolare se i candidati inviano la relativa documentazione di candidatura anche via e-mail (ad esempio in formato PDF o altri tipi di file).
+Il responsabile del trattamento raccoglie e tratta i dati personali dei candidati allo scopo di eseguire il processo di candidatura. Questo trattamento avviene tramite LinkedIn.
 
 Se ti candidi per un posto di lavoro da noi pubblicizzato, queste disposizioni sulla protezione dei dati si applicano in aggiunta alle nostre altre disposizioni sulla protezione dei dati, che ti sono state comunicate separatamente o sono disponibili sul nostro sito web.
 


### PR DESCRIPTION
EN:
This pulls the English, French and Italian privacy policy and FAQ to the merged German text. Support is the app form only, Swissquote blocks are on their side, and retention including IP addresses is ten years. Line counts stay identical across the four languages.

DE:
Dieser Stand zieht die englische, französische und italienische Datenschutzerklärung und FAQ auf den gemergten deutschen Text. Support läuft nur über das App-Formular, die Swissquote-Sperre kommt von dort, und die Aufbewahrung inklusive IP-Adressen beträgt zehn Jahre. Die Zeilenzahl ist in allen vier Sprachen identisch.

<details>
<summary>Details</summary>

Source of truth is the merged German of #139. EN/FR/IT now match:

- Support links use https://app.dfx.swiss/support (no contact email)
- Swissquote/Yuh: the block comes from those banks, not DFX; transfers from those accounts cannot be processed
- Official IDs are personal data but not particularly sensitive under Art. 5(c) FADP
- Profiling only for AML/sanctions and partner-bank requirements; no credit checks
- Dilisense receives name and date of birth only
- 10-year retention including IP/log data (Art. 7 AMLA); no 6-month IP period
- Applications exclusively via LinkedIn
- FR statute name on the legal-obligations bullet is the Swiss LPD, not the French Informatique et Libertés act

Invariant: newline counts are equal (faq.md 212, privacy.md 358) and heading line numbers match. Terms and conditions were not changed.

</details>